### PR TITLE
avoid creating `nodescaleadjuster` artefacts when disabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ manifests: controller-gen kustomize ## Generate ClusterRole and CustomResourceDe
 	$(CONTROLLER_GEN) rbac:roleName=kai-binder,headerFile="./hack/boilerplate.yaml.txt" paths="./pkg/binder/..." paths="./cmd/binder/..." output:stdout > deployments/kai-scheduler/templates/rbac/binder.yaml
 	$(CONTROLLER_GEN) rbac:roleName=kai-resource-reservation,headerFile="./hack/boilerplate.yaml.txt" paths="./pkg/resourcereservation/..." paths="./cmd/resourcereservation/..." output:stdout > deployments/kai-scheduler/templates/rbac/resourcereservation.yaml
 	$(CONTROLLER_GEN) rbac:roleName=kai-scheduler,headerFile="./hack/boilerplate.yaml.txt" paths="./pkg/scheduler/..." paths="./cmd/scheduler/..." output:stdout > deployments/kai-scheduler/templates/rbac/scheduler.yaml
-	$(CONTROLLER_GEN) rbac:roleName=kai-node-scale-adjuster,headerFile="./hack/boilerplate.yaml.txt" paths="./pkg/nodescaleadjuster/..." paths="./cmd/nodescaleadjuster/..." output:stdout > deployments/kai-scheduler/templates/rbac/nodescaleadjuster.yaml
 	$(CONTROLLER_GEN) rbac:roleName=kai-podgroup-controller,headerFile="./hack/boilerplate.yaml.txt" paths="./pkg/podgroupcontroller/..." paths="./cmd/podgroupcontroller/..." output:stdout > deployments/kai-scheduler/templates/rbac/podgroupcontroller.yaml
 
 	$(CONTROLLER_GEN) rbac:roleName=kai-webhookmanager,headerFile="./hack/boilerplate.yaml.txt" paths="./pkg/webhookmanager/..." paths="./cmd/webhookmanager/..." output:stdout > deployments/kustomization/webhookmanager-clusterrole/resource.yaml

--- a/deployments/kai-scheduler/templates/rbac/nodescaleadjuster-binding.yaml
+++ b/deployments/kai-scheduler/templates/rbac/nodescaleadjuster-binding.yaml
@@ -1,6 +1,6 @@
 # Copyright 2025 NVIDIA CORPORATION
   # SPDX-License-Identifier: Apache-2.0
----
+{{- if .Values.global.clusterAutoscaling }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,3 +13,4 @@ roleRef:
   kind: ClusterRole
   name: kai-node-scale-adjuster
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deployments/kai-scheduler/templates/rbac/nodescaleadjuster.yaml
+++ b/deployments/kai-scheduler/templates/rbac/nodescaleadjuster.yaml
@@ -1,6 +1,6 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
----
+{{- if .Values.global.clusterAutoscaling }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -34,3 +34,4 @@ rules:
   - get
   - patch
   - update
+{{- end }}

--- a/deployments/kai-scheduler/templates/services/nodescaleadjuster-serviceaccount.yaml
+++ b/deployments/kai-scheduler/templates/services/nodescaleadjuster-serviceaccount.yaml
@@ -1,7 +1,9 @@
 # Copyright 2025 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.global.clusterAutoscaling }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: node-scale-adjuster
+{{- end }}


### PR DESCRIPTION
the `Deployment` already [has this](https://github.com/NVIDIA/KAI-Scheduler/blob/a1f3cd1a074503e5dbddd5b1803fc1bd7625f836/deployments/kai-scheduler/templates/services/nodescaleadjuster.yaml#L4) guard. It should be extended to include its IAM and service.