### PR TITLE
feat(chart): Add PDB for kai operator

### DIFF
--- a/deployments/kai-scheduler/templates/_helpers.tpl
+++ b/deployments/kai-scheduler/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+{{/*
+Operator PodDisruptionBudget: merge values.operator.podDisruptionBudget with safe defaults.
+Uses hasKey (not default) so enabled: false and maxUnavailable: 0 are respected (Sprig default() treats them as empty).
+
+Returns a small YAML object with keys: enabled, maxUnavailable
+*/}}
+{{- define "kai-scheduler.operator.podDisruptionBudgetConfig" -}}
+{{- $pdb := .Values.operator.podDisruptionBudget | default dict }}
+{{- $pdbEnabled := true }}
+{{- if hasKey $pdb "enabled" }}
+{{-   $pdbEnabled = $pdb.enabled }}
+{{- end }}
+{{- $maxUnavailable := 1 }}
+{{- if hasKey $pdb "maxUnavailable" }}
+{{-   $maxUnavailable = int $pdb.maxUnavailable }}
+{{- end }}
+{{- dict "enabled" $pdbEnabled "maxUnavailable" $maxUnavailable | toYaml }}
+{{- end }}

--- a/deployments/kai-scheduler/templates/services/operator-poddisruptionbudget.yaml
+++ b/deployments/kai-scheduler/templates/services/operator-poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+# Copyright 2025 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+{{- $cfg := fromYaml (include "kai-scheduler.operator.podDisruptionBudgetConfig" .) }}
+{{- if and $cfg.enabled (gt (int .Values.operator.replicaCount) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kai-operator-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kai-operator
+spec:
+  maxUnavailable: {{ $cfg.maxUnavailable }}
+  selector:
+    matchLabels:
+      app: kai-operator
+{{- end }}

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -45,6 +45,12 @@ operator:
   probeBindAddress: ":8081"
   qps: 50
   burst: 300
+  # PodDisruptionBudget limits voluntary evictions (drain) so not all operator pods are removed at once.
+  # Renders only when operator.replicaCount > 1. With a single replica, a PDB (e.g. minAvailable: 1) can
+  # block drains; maxUnavailable is not used for replicaCount: 1 by default.
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
 
 podgrouper:
   enabled: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

Add Helm support for creating a PodDisruptionBudget for the operator deployment (kai-operator), with configurable values in values.yaml.


## Related Issues

Fixes https://github.com/kai-scheduler/KAI-Scheduler/issues/1477

## Checklist


- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [x] Updated documentation (if needed)

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
