### PR TITLE
perf(scheduler): add accumulated scenario input cursors

### DIFF
--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/Interface.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/Interface.go
@@ -3,9 +3,7 @@
 
 package accumulated_scenario_filters
 
-import "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
-
 type Interface interface {
 	Name() string
-	Filter(*scenario.ByNodeScenario) (bool, error)
+	Filter(AccumulatedScenarioInput) (bool, error)
 }

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/idle_gpus.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/idle_gpus.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/exp/slices"
 
+	inputfilters "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
@@ -47,6 +48,8 @@ type AccumulatedIdleGpus struct {
 	// This helps us to calculate "gpus freed by victim task eviction" only once for each task,
 	// even if multiple scenarios reference to a single task as a victim.
 	potentialVictimsInCache map[common_info.PodID]bool
+	recordedVictimsCursor   inputfilters.VictimTaskCursor
+	potentialVictimsCursor  inputfilters.VictimTaskCursor
 
 	// We have a separate map for each type of task to help with scenario accumulated build assertions.
 }
@@ -62,7 +65,7 @@ func NewIdleGpusFilter(
 		recordedVictimsInCache:  make(map[common_info.PodID]bool),
 		potentialVictimsInCache: make(map[common_info.PodID]bool),
 	}
-	err := filter.updateStateWithScenario(scenario, true)
+	err := filter.updateStateWithScenario(inputfilters.NewFullScanScenarioInput(scenario), true)
 	if err != nil {
 		return nil
 	}
@@ -74,8 +77,8 @@ func (ig *AccumulatedIdleGpus) Name() string {
 	return idleGpuFilterName
 }
 
-func (ig *AccumulatedIdleGpus) Filter(scenario *scenario.ByNodeScenario) (bool, error) {
-	err := ig.updateStateWithScenario(scenario, false)
+func (ig *AccumulatedIdleGpus) Filter(input inputfilters.AccumulatedScenarioInput) (bool, error) {
+	err := ig.updateStateWithScenario(input, false)
 	if err != nil {
 		return false, err
 	}
@@ -87,35 +90,46 @@ func (ig *AccumulatedIdleGpus) Filter(scenario *scenario.ByNodeScenario) (bool, 
 	), nil
 }
 
-func (ig *AccumulatedIdleGpus) updateStateWithScenario(scenario *scenario.ByNodeScenario, isFirstScenario bool) error {
+func (ig *AccumulatedIdleGpus) updateStateWithScenario(
+	input inputfilters.AccumulatedScenarioInput, isFirstScenario bool,
+) error {
+	scenario := input.Scenario()
 	err := ig.updateRequiredResources(scenario, isFirstScenario)
 	if err != nil {
 		return err
 	}
 
 	preUpdateRecordedVictimsCacheSize := len(ig.recordedVictimsInCache)
-	recordedVictimsCacheHits := ig.updateVictimList(scenario.RecordedVictimsTasks(), ig.recordedVictimsInCache)
+	recordedVictimsDelta := input.RecordedVictimsSince(ig.recordedVictimsCursor)
+	recordedVictimsCacheHits := ig.updateVictimList(recordedVictimsDelta, ig.recordedVictimsInCache)
 	if err = ig.assertRecordedVictimsState(isFirstScenario, len(ig.recordedVictimsInCache), preUpdateRecordedVictimsCacheSize, recordedVictimsCacheHits); err != nil {
 		return err
 	}
+	ig.recordedVictimsCursor = recordedVictimsDelta.Next
 
 	preUpdatePotentialVictimsCacheSize := len(ig.potentialVictimsInCache)
-	potentialVictimsCacheHits := ig.updateVictimList(scenario.PotentialVictimsTasks(), ig.potentialVictimsInCache)
+	potentialVictimsDelta := input.PotentialVictimsSince(ig.potentialVictimsCursor)
+	potentialVictimsCacheHits := ig.updateVictimList(potentialVictimsDelta, ig.potentialVictimsInCache)
 	if err = ig.assertPotentialVictimsState(potentialVictimsCacheHits, preUpdatePotentialVictimsCacheSize); err != nil {
 		return err
 	}
+	ig.potentialVictimsCursor = potentialVictimsDelta.Next
 	return nil
 }
 
 func (ig *AccumulatedIdleGpus) updateVictimList(
-	victimTasks []*pod_info.PodInfo, relevantCacheData map[common_info.PodID]bool,
+	victimsDelta inputfilters.VictimTaskDelta, relevantCacheData map[common_info.PodID]bool,
 ) int {
 	var minIdleGpusRelevant string
 	if len(ig.maxFreeGpuNodesSorted) > 0 {
 		minIdleGpusRelevant = ig.maxFreeGpuNodesSorted[len(ig.maxFreeGpuNodesSorted)-1]
 	}
 
-	return iterateNewVictims(victimTasks, relevantCacheData, func(task *pod_info.PodInfo) {
+	previousCacheHits := 0
+	if victimsDelta.Monotonic {
+		previousCacheHits = len(relevantCacheData)
+	}
+	return previousCacheHits + iterateNewVictims(victimsDelta.Tasks, relevantCacheData, func(task *pod_info.PodInfo) {
 		minIdleGpusRelevant = ig.updateWithVictim(task, minIdleGpusRelevant)
 	})
 }

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/idle_gpus_test.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/idle_gpus_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	inputfilters "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
@@ -896,7 +897,7 @@ func TestAccumulatedIdleGpus_updateStateWithScenario(t *testing.T) {
 				recordedVictimsInCache:  tt.fields.recordedVictimsInCache,
 				potentialVictimsInCache: tt.fields.potentialVictimsInCache,
 			}
-			err := ig.updateStateWithScenario(tt.args.scenario, tt.args.isFirstScenario)
+			err := ig.updateStateWithScenario(inputfilters.NewFullScanScenarioInput(tt.args.scenario), tt.args.isFirstScenario)
 			if err != nil != tt.want.wantErr {
 				t.Errorf("updateStateWithScenario() error = %v, err %v", err, tt.want.wantErr)
 			}
@@ -1367,7 +1368,7 @@ func TestAccumulatedIdleGpus_Filter(t *testing.T) {
 				recordedVictimsInCache:  tt.fields.recordedVictimsInCache,
 				potentialVictimsInCache: tt.fields.potentialVictimsInCache,
 			}
-			validScenario, err := ig.Filter(tt.args.scenario)
+			validScenario, err := ig.Filter(inputfilters.NewFullScanScenarioInput(tt.args.scenario))
 			if (err != nil) != tt.want.err {
 				t.Errorf("Filter() error = %v, err %v", err, tt.want.err)
 				return

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/topology_aware_idle_gpus.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/topology_aware_idle_gpus.go
@@ -6,6 +6,7 @@ package accumulated_scenario_filters
 import (
 	"sort"
 
+	inputfilters "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
@@ -39,7 +40,9 @@ type TopologyAwareIdleGpus struct {
 	domainsByConstraint map[constraintGroupKey][]TopologyDomainKey
 	// processedVictims tracks victim UIDs that have already had their freed GPUs applied to
 	// domainCapacity, preventing double-counting when the same victim appears across calls.
-	processedVictims map[common_info.PodID]bool
+	processedVictims       map[common_info.PodID]bool
+	recordedVictimsCursor  inputfilters.VictimTaskCursor
+	potentialVictimsCursor inputfilters.VictimTaskCursor
 }
 
 func NewTopologyAwareIdleGpusFilter(
@@ -66,17 +69,22 @@ func (taf *TopologyAwareIdleGpus) Name() string {
 	return topologyAwareIdleGpuFilterName
 }
 
-func (taf *TopologyAwareIdleGpus) Filter(scenario *scenario.ByNodeScenario) (bool, error) {
-	taf.updateDomainCapacityWithVictims(scenario)
+func (taf *TopologyAwareIdleGpus) Filter(input inputfilters.AccumulatedScenarioInput) (bool, error) {
+	taf.updateDomainCapacityWithVictims(input)
 	return taf.requiredTopologyCapacityExists(), nil
 }
 
 // updateDomainCapacityWithVictims updates domain capacities when new victims are added.
 // After each capacity increase it repositions the domain in the pre-sorted slice so the
 // slice stays ordered without a full re-sort.
-func (taf *TopologyAwareIdleGpus) updateDomainCapacityWithVictims(scenario *scenario.ByNodeScenario) {
-	taf.applyVictimTasks(scenario.RecordedVictimsTasks())
-	taf.applyVictimTasks(scenario.PotentialVictimsTasks())
+func (taf *TopologyAwareIdleGpus) updateDomainCapacityWithVictims(input inputfilters.AccumulatedScenarioInput) {
+	recordedVictimsDelta := input.RecordedVictimsSince(taf.recordedVictimsCursor)
+	taf.applyVictimTasks(recordedVictimsDelta.Tasks)
+	taf.recordedVictimsCursor = recordedVictimsDelta.Next
+
+	potentialVictimsDelta := input.PotentialVictimsSince(taf.potentialVictimsCursor)
+	taf.applyVictimTasks(potentialVictimsDelta.Tasks)
+	taf.potentialVictimsCursor = potentialVictimsDelta.Next
 }
 
 func (taf *TopologyAwareIdleGpus) applyVictimTasks(victimTasks []*pod_info.PodInfo) {

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/topology_aware_idle_gpus_test.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/idle_gpus/topology_aware_idle_gpus_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	inputfilters "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
@@ -612,7 +613,7 @@ func buildJob(name string, tasks []*tasks_fake.TestTaskBasic, rootSubGroupSet *s
 // runFilterCheck runs the filter and asserts the expected validity.
 func runFilterCheck(t *testing.T, filter *TopologyAwareIdleGpus, s *scenario.ByNodeScenario, wantValid bool, reason string) {
 	t.Helper()
-	valid, err := filter.Filter(s)
+	valid, err := filter.Filter(inputfilters.NewFullScanScenarioInput(s))
 	if err != nil {
 		t.Fatalf("Filter returned error: %v", err)
 	}

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/input.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/input.go
@@ -1,0 +1,88 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package accumulated_scenario_filters
+
+import (
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+)
+
+type VictimTaskCursor struct {
+	Len int
+}
+
+type VictimTaskDelta struct {
+	Tasks     []*pod_info.PodInfo
+	Next      VictimTaskCursor
+	Monotonic bool
+}
+
+type AccumulatedScenarioInput interface {
+	Scenario() *scenario.ByNodeScenario
+	PotentialVictimsSince(cursor VictimTaskCursor) VictimTaskDelta
+	RecordedVictimsSince(cursor VictimTaskCursor) VictimTaskDelta
+}
+
+type MonotonicScenarioInput struct {
+	scenario *scenario.ByNodeScenario
+}
+
+func NewMonotonicScenarioInput(scenario *scenario.ByNodeScenario) MonotonicScenarioInput {
+	return MonotonicScenarioInput{scenario: scenario}
+}
+
+func (input MonotonicScenarioInput) Scenario() *scenario.ByNodeScenario {
+	return input.scenario
+}
+
+func (input MonotonicScenarioInput) PotentialVictimsSince(cursor VictimTaskCursor) VictimTaskDelta {
+	return monotonicVictimDelta(input.scenario.PotentialVictimsTasks(), cursor)
+}
+
+func (input MonotonicScenarioInput) RecordedVictimsSince(cursor VictimTaskCursor) VictimTaskDelta {
+	return monotonicVictimDelta(input.scenario.RecordedVictimsTasks(), cursor)
+}
+
+type FullScanScenarioInput struct {
+	scenario *scenario.ByNodeScenario
+}
+
+func NewFullScanScenarioInput(scenario *scenario.ByNodeScenario) FullScanScenarioInput {
+	return FullScanScenarioInput{scenario: scenario}
+}
+
+func (input FullScanScenarioInput) Scenario() *scenario.ByNodeScenario {
+	return input.scenario
+}
+
+func (input FullScanScenarioInput) PotentialVictimsSince(_ VictimTaskCursor) VictimTaskDelta {
+	victims := input.scenario.PotentialVictimsTasks()
+	return VictimTaskDelta{
+		Tasks: victims,
+		Next:  VictimTaskCursor{Len: len(victims)},
+	}
+}
+
+func (input FullScanScenarioInput) RecordedVictimsSince(_ VictimTaskCursor) VictimTaskDelta {
+	victims := input.scenario.RecordedVictimsTasks()
+	return VictimTaskDelta{
+		Tasks: victims,
+		Next:  VictimTaskCursor{Len: len(victims)},
+	}
+}
+
+func monotonicVictimDelta(victims []*pod_info.PodInfo, cursor VictimTaskCursor) VictimTaskDelta {
+	next := VictimTaskCursor{Len: len(victims)}
+	if cursor.Len > len(victims) {
+		return VictimTaskDelta{
+			Tasks: victims,
+			Next:  next,
+		}
+	}
+	return VictimTaskDelta{
+		Tasks:     victims[cursor.Len:],
+		Next:      next,
+		Monotonic: true,
+	}
+}

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/input_test.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/input_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package accumulated_scenario_filters
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/framework"
+)
+
+func TestMonotonicScenarioInputPotentialVictimsSinceReturnsAppendedSuffix(t *testing.T) {
+	first := inputTestTask("victim-1", "victim-job")
+	second := inputTestTask("victim-2", "victim-job")
+	third := inputTestTask("victim-3", "victim-job")
+	testScenario := inputTestScenario(nil, []*pod_info.PodInfo{first, second}, nil)
+
+	input := NewMonotonicScenarioInput(testScenario)
+	delta := input.PotentialVictimsSince(VictimTaskCursor{})
+	assertInputTestDelta(t, delta, true, 2, first, second)
+
+	testScenario.AddPotentialVictimsTasks([]*pod_info.PodInfo{third})
+	delta = input.PotentialVictimsSince(delta.Next)
+	assertInputTestDelta(t, delta, true, 3, third)
+}
+
+func TestMonotonicScenarioInputFallsBackWhenCursorIsAhead(t *testing.T) {
+	first := inputTestTask("victim-1", "victim-job")
+	second := inputTestTask("victim-2", "victim-job")
+	testScenario := inputTestScenario(nil, []*pod_info.PodInfo{first, second}, nil)
+
+	input := NewMonotonicScenarioInput(testScenario)
+	delta := input.PotentialVictimsSince(VictimTaskCursor{Len: 10})
+
+	assertInputTestDelta(t, delta, false, 2, first, second)
+}
+
+func TestFullScanScenarioInputAlwaysReturnsFullVictimLists(t *testing.T) {
+	recorded := inputTestTask("recorded-1", "recorded-job")
+	potential := inputTestTask("victim-1", "victim-job")
+	recordedJob := podgroup_info.NewPodGroupInfo("recorded-job", recorded)
+	testScenario := inputTestScenario(nil, []*pod_info.PodInfo{potential}, []*podgroup_info.PodGroupInfo{recordedJob})
+
+	input := NewFullScanScenarioInput(testScenario)
+
+	potentialDelta := input.PotentialVictimsSince(VictimTaskCursor{Len: 1})
+	assertInputTestDelta(t, potentialDelta, false, 1, potential)
+
+	recordedDelta := input.RecordedVictimsSince(VictimTaskCursor{Len: 1})
+	assertInputTestDelta(t, recordedDelta, false, 1, recorded)
+}
+
+func assertInputTestDelta(
+	t *testing.T,
+	delta VictimTaskDelta,
+	wantMonotonic bool,
+	wantNextLen int,
+	wantTasks ...*pod_info.PodInfo,
+) {
+	t.Helper()
+	if delta.Monotonic != wantMonotonic {
+		t.Fatalf("Monotonic = %v, want %v", delta.Monotonic, wantMonotonic)
+	}
+	if delta.Next.Len != wantNextLen {
+		t.Fatalf("Next.Len = %d, want %d", delta.Next.Len, wantNextLen)
+	}
+	if len(delta.Tasks) != len(wantTasks) {
+		t.Fatalf("len(Tasks) = %d, want %d", len(delta.Tasks), len(wantTasks))
+	}
+	for i, wantTask := range wantTasks {
+		if delta.Tasks[i] != wantTask {
+			t.Fatalf("Tasks[%d] = %v, want %v", i, delta.Tasks[i].UID, wantTask.UID)
+		}
+	}
+}
+
+func inputTestScenario(
+	pendingTasks []*pod_info.PodInfo,
+	potentialVictims []*pod_info.PodInfo,
+	recordedVictimJobs []*podgroup_info.PodGroupInfo,
+) *scenario.ByNodeScenario {
+	ssn := &framework.Session{ClusterInfo: api.NewClusterInfo()}
+	pendingJob := podgroup_info.NewPodGroupInfo("pending-job", pendingTasks...)
+	ssn.ClusterInfo.PodGroupInfos[pendingJob.UID] = pendingJob
+	for _, task := range potentialVictims {
+		if _, ok := ssn.ClusterInfo.PodGroupInfos[task.Job]; !ok {
+			ssn.ClusterInfo.PodGroupInfos[task.Job] = podgroup_info.NewPodGroupInfo(task.Job)
+		}
+	}
+	for _, victimJob := range recordedVictimJobs {
+		ssn.ClusterInfo.PodGroupInfos[victimJob.UID] = victimJob
+	}
+	return scenario.NewByNodeScenario(ssn, pendingJob, pendingTasks, potentialVictims, recordedVictimJobs)
+}
+
+func inputTestTask(uid, jobID string) *pod_info.PodInfo {
+	return pod_info.NewTaskInfo(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID(uid),
+			Name:      uid,
+			Namespace: "test",
+			Annotations: map[string]string{
+				commonconstants.PodGroupAnnotationForPod: jobID,
+			},
+		},
+	}, resource_info.NewResourceVectorMap())
+}

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/node_affinities/node_affinities.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/node_affinities/node_affinities.go
@@ -13,6 +13,7 @@ import (
 	ksf "k8s.io/kube-scheduler/framework"
 	k8sframework "k8s.io/kubernetes/pkg/scheduler/framework"
 
+	inputfilters "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
@@ -26,11 +27,13 @@ const (
 )
 
 type NodeAffinitiesFilter struct {
-	allNodes           map[string]*v1.Node
-	allNodeInfos       map[string]*k8sframework.NodeInfo
-	feasibleNodes      map[string]*v1.Node
-	processedVictims   map[common_info.PodID]bool
-	nodeAffinityPlugin ksf.Plugin
+	allNodes               map[string]*v1.Node
+	allNodeInfos           map[string]*k8sframework.NodeInfo
+	feasibleNodes          map[string]*v1.Node
+	processedVictims       map[common_info.PodID]bool
+	recordedVictimsCursor  inputfilters.VictimTaskCursor
+	potentialVictimsCursor inputfilters.VictimTaskCursor
+	nodeAffinityPlugin     ksf.Plugin
 }
 
 func NewNodeAffinitiesFilter(
@@ -50,7 +53,7 @@ func NewNodeAffinitiesFilter(
 		nodeAffinityPlugin: session.Cache.InternalK8sPlugins().NodeAffinity,
 	}
 	nodeAffinitiesFilter.initNodeMaps(feasibleNodeInfos, session)
-	nodeAffinitiesFilter.updateStateWithScenario(scenario)
+	nodeAffinitiesFilter.updateStateWithScenario(inputfilters.NewFullScanScenarioInput(scenario))
 
 	return nodeAffinitiesFilter
 }
@@ -78,18 +81,23 @@ func (naf *NodeAffinitiesFilter) Name() string {
 	return nodeAffinitiesFilterName
 }
 
-func (naf *NodeAffinitiesFilter) Filter(scenario *scenario.ByNodeScenario) (bool, error) {
-	naf.updateStateWithScenario(scenario)
-	return naf.allPendingPodsHaveMatchingNodes(scenario), nil
+func (naf *NodeAffinitiesFilter) Filter(input inputfilters.AccumulatedScenarioInput) (bool, error) {
+	naf.updateStateWithScenario(input)
+	return naf.allPendingPodsHaveMatchingNodes(input.Scenario()), nil
 }
 
-func (naf *NodeAffinitiesFilter) updateStateWithScenario(scenario *scenario.ByNodeScenario) {
-	for _, task := range scenario.PotentialVictimsTasks() {
+func (naf *NodeAffinitiesFilter) updateStateWithScenario(input inputfilters.AccumulatedScenarioInput) {
+	potentialVictimsDelta := input.PotentialVictimsSince(naf.potentialVictimsCursor)
+	for _, task := range potentialVictimsDelta.Tasks {
 		naf.updateVictimNodesFromTask(task)
 	}
-	for _, task := range scenario.RecordedVictimsTasks() {
+	naf.potentialVictimsCursor = potentialVictimsDelta.Next
+
+	recordedVictimsDelta := input.RecordedVictimsSince(naf.recordedVictimsCursor)
+	for _, task := range recordedVictimsDelta.Tasks {
 		naf.updateVictimNodesFromTask(task)
 	}
+	naf.recordedVictimsCursor = recordedVictimsDelta.Next
 }
 
 func (naf *NodeAffinitiesFilter) updateVictimNodesFromTask(task *pod_info.PodInfo) {

--- a/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/node_affinities/node_affinities_test.go
+++ b/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters/node_affinities/node_affinities_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	inputfilters "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
@@ -424,7 +425,7 @@ func TestNodeAffinitiesFilter_Filter(t *testing.T) {
 
 			// Create the filter scenario (with victims) and call Filter
 			filterSc := scenario.NewByNodeScenario(ssn, nil, tt.pendingTasks, tt.victimTasks, []*podgroup_info.PodGroupInfo{})
-			got, err := filter.Filter(filterSc)
+			got, err := filter.Filter(inputfilters.NewFullScanScenarioInput(filterSc))
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantFilterResult, got)
 		})

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
@@ -211,8 +211,9 @@ func (asb *PodAccumulatedScenarioBuilder) addNextPotentialVictims() bool {
 }
 
 func (asb *PodAccumulatedScenarioBuilder) isScenarioValid() (bool, string) {
+	input := accumulated_scenario_filters.NewMonotonicScenarioInput(asb.lastScenario)
 	for _, filter := range asb.scenarioFilters {
-		validScenario, err := filter.Filter(asb.lastScenario)
+		validScenario, err := filter.Filter(input)
 		if err != nil {
 			log.InfraLogger.Errorf("Failed to run the filter %s with the error %v. scenario: %s", filter.Name(), err,
 				asb.lastScenario)

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder_test.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder_test.go
@@ -21,6 +21,7 @@ import (
 	schedulingv2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2"
 	schedulingv2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/accumulated_scenario_filters"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/common/solvers/scenario"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/utils"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api"
@@ -285,6 +286,39 @@ var _ = Describe("PodAccumulatedScenarioBuilder", func() {
 		})
 	})
 })
+
+func TestPodAccumulatedScenarioBuilderPassesMonotonicInputToFilters(t *testing.T) {
+	testScenario := scenario.NewByNodeScenario(nil, nil, nil, nil, nil)
+	filter := &recordingAccumulatedFilter{}
+	scenarioBuilder := &PodAccumulatedScenarioBuilder{
+		lastScenario:    testScenario,
+		scenarioFilters: []accumulated_scenario_filters.Interface{filter},
+	}
+
+	isValid, failedFilterName := scenarioBuilder.isScenarioValid()
+	if !isValid {
+		t.Fatalf("isScenarioValid() = false, failedFilterName = %q", failedFilterName)
+	}
+	if !filter.gotMonotonicInput {
+		t.Fatal("filter did not receive monotonic scenario input")
+	}
+}
+
+type recordingAccumulatedFilter struct {
+	gotMonotonicInput bool
+}
+
+func (filter *recordingAccumulatedFilter) Name() string {
+	return "recording"
+}
+
+func (filter *recordingAccumulatedFilter) Filter(
+	input accumulated_scenario_filters.AccumulatedScenarioInput,
+) (bool, error) {
+	delta := input.PotentialVictimsSince(accumulated_scenario_filters.VictimTaskCursor{})
+	filter.gotMonotonicInput = delta.Monotonic
+	return true, nil
+}
 
 func initializeSession(jobsCount, tasksPerJob int) (*framework.Session, []*pod_info.PodInfo) {
 	tasks := []*pod_info.PodInfo{}


### PR DESCRIPTION
## Description

Add a cursor-aware `AccumulatedScenarioInput` API for reclaim accumulated scenario filters.

## Motivation

`BenchmarkReclaimLargeJobs_1000Node` showed reclaim spending a large share of CPU time rescanning already-processed victim tasks in accumulated scenario filters. The production `PodAccumulatedScenarioBuilder` grows its outer scenario monotonically by appending potential victims, but the filter API only exposed the full `ByNodeScenario`. Because that append-only contract was implicit, filters repeatedly scanned the full victim prefix and relied on processed-victim maps to avoid double-counting.

This was correct, but expensive at large scale. The profile showed the hot path dominated by repeated map lookups from `iterateNewVictims`, especially through `AccumulatedIdleGpus.updateStateWithScenario`.

## Solution

Introduce `AccumulatedScenarioInput`, which lets filters request victim deltas through per-filter cursors:

- `MonotonicScenarioInput` exposes appended victim suffixes for the production builder path.
- `FullScanScenarioInput` preserves current full-scan behavior for direct tests and any future non-monotonic caller.
- Each filter owns its own cursor, so multiple filters can consume the same input independently.
- Existing processed-victim maps remain in place as the fallback correctness mechanism.

Updated filters:
- `AccumulatedIdleGpus`
- `TopologyAwareIdleGpus`
- `NodeAffinitiesFilter`

`PodAccumulatedScenarioBuilder` now wraps its accumulated outer scenario with `NewMonotonicScenarioInput` before invoking filters.

## Related Issues

N/A

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests
- [ ] Updated documentation

## Breaking Changes

None.

## Additional Notes

N/A
