### PR TITLE
ci(release): default prepare-changelog version to next patch

### DIFF
--- a/.github/workflows/release-prepare.yaml
+++ b/.github/workflows/release-prepare.yaml
@@ -7,6 +7,9 @@
 # "## [VERSION]" section, clears the fragments, and opens a PR against the branch this workflow
 # was dispatched on (main for minors/majors, a v*.* branch for patches).
 #
+# Leaving the version input empty on a v*.* branch releases the next patch of that branch
+# (highest existing vMAJOR.MINOR.PATCH tag + 1, or .0 if none). On main the version is required.
+#
 # A maintainer reviews and merges that PR. Merging it triggers release-publish.yaml (step 2),
 # which tags the version and creates the GitHub Release.
 
@@ -16,8 +19,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to release, e.g. v0.17.0 (minors/majors from main, patches from a v*.* branch)'
-        required: true
+        description: 'Version to release, e.g. v0.17.0. Leave empty on a v*.* branch for the next patch. Required on main.'
+        required: false
         type: string
 
 permissions:
@@ -33,7 +36,43 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.KAIBOT_TOKEN }}
+
+      - name: Resolve version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          VERSION="$(echo "$INPUT_VERSION" | tr -d '[:space:]')"
+
+          if [ -z "$VERSION" ]; then
+            # No version given: derive the next patch of the v*.* branch this ran on.
+            if ! echo "$BRANCH" | grep -qE '^v[0-9]+\.[0-9]+$'; then
+              echo "::error::Branch '$BRANCH' is not a v*.* release branch — pass the version input explicitly"; exit 1
+            fi
+            # Ignore pre-release tags (v0.16.1-rc.0) and the bare branch-shaped tag (v0.16).
+            LATEST="$(git tag -l "$BRANCH.*" | grep -E "^${BRANCH//./\\.}\.[0-9]+$" | sort -V | tail -1 || true)"
+            if [ -z "$LATEST" ]; then
+              VERSION="$BRANCH.0"
+            else
+              VERSION="$BRANCH.$(( ${LATEST##*.} + 1 ))"
+            fi
+            echo "Derived version $VERSION from branch $BRANCH (latest tag: ${LATEST:-none})"
+          fi
+
+          if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::Version '$VERSION' is not of the form vMAJOR.MINOR.PATCH"; exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "::error::Tag $VERSION already exists"; exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Preparing release $VERSION on $BRANCH"
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -41,12 +80,12 @@ jobs:
           go-version: '1.26.3'
 
       - name: Fold fragments into CHANGELOG.md
-        run: make changelog-release VERSION="${{ inputs.version }}"
+        run: make changelog-release VERSION="${{ steps.version.outputs.version }}"
 
       - name: Open release PR
         env:
           GH_TOKEN: ${{ secrets.KAIBOT_TOKEN }}
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
           BASE: ${{ github.ref_name }}
         run: |
           set -euo pipefail

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,7 @@ make changelog-preview VERSION=v0.17.0
 
 **Humans:** `make changelog` with no args runs the interactive prompts.
 
-**Releasing (maintainers):** don't fold the changelog by hand. Dispatch the **Release — Prepare Changelog** workflow with a version (e.g. `v0.17.0`) from the target branch — `main` for a minor/major, a `v*.*` branch for a patch. It folds the pending fragments into `CHANGELOG.md`, clears them, and opens a PR. Merging that PR auto-tags the version and publishes the GitHub Release.
+**Releasing (maintainers):** don't fold the changelog by hand. Dispatch the **Release — Prepare Changelog** workflow from the target branch — `main` for a minor/major, a `v*.*` branch for a patch. The version input (e.g. `v0.17.0`) is required on `main`; on a `v*.*` branch leave it empty to release the next patch of that branch. It folds the pending fragments into `CHANGELOG.md`, clears them, and opens a PR. Merging that PR auto-tags the version and publishes the GitHub Release.
 
 ### CI Checks (on-pr.yaml)
 PRs trigger: `make validate` → `make test` → `make build` → E2E tests


### PR DESCRIPTION
## Description

Makes the `version` input of the **Release — Prepare Changelog** workflow optional. When it is left empty, the workflow derives the next patch version of the `v*.*` branch it was dispatched on, so routine patch releases no longer require looking up the last tag by hand.

A new **Resolve version** step:

- uses the input verbatim when provided (whitespace trimmed);
- when empty, requires the branch to match `^v[0-9]+\.[0-9]+$` and resolves `<branch>.<highest patch + 1>`, falling back to `<branch>.0` if the branch has no patch tags yet;
- filters tags to strict `vMAJOR.MINOR.PATCH` so pre-releases (`v0.16.1-rc.0`) and the bare branch-shaped tag (`v0.16`) don't skew the result, and uses `sort -V` so `v0.9.20` beats `v0.9.9`;
- fails with a clear error when dispatched on `main` (or any non-`v*.*` branch) without a version;
- validates the resolved version's shape and fails early if that tag already exists — previously this only surfaced at publish time.

`fetch-tags: true` was added to the checkout so the tag lookup is reliable, and the fold/PR steps now read `steps.version.outputs.version`.

## Related Issues

N/A

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed) — n/a, workflow-only change; derivation logic was exercised locally against the repo's tag set
- [x] Updated documentation (if needed) — maintainer release note in `AGENTS.md` (`CLAUDE.md` symlinks to it)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label) — CI-only, `skip-changelog` applied

## Breaking Changes

None. Passing an explicit version behaves exactly as before.

## Additional Notes

`release-publish.yaml` is unchanged — it still derives the version from the folded `CHANGELOG.md` heading and cross-checks it against the `release/prepare-*` branch name, so the resolved version flows through unchanged.
