### PR TITLE
chore: disable CodeRabbit review status

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,6 +5,7 @@
 language: "en-US"
 
 reviews:
+  review_status: false
   auto_review:
     enabled: false
   finishing_touches:


### PR DESCRIPTION
## Summary

- Add \`review_status: false\` to \`.coderabbit.yaml\` to disable CodeRabbit's review status comments on PRs

## Test plan

- [ ] Verify CodeRabbit no longer posts review status on new PRs