### PR TITLE
fix: propagate Kubernetes client arguments

### DIFF
--- a/.changes/unreleased/fixed-20260806-221852.yaml
+++ b/.changes/unreleased/fixed-20260806-221852.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Propagate Kubernetes client QPS and burst settings to operator-managed controllers

--- a/pkg/operator/operands/admission/resources.go
+++ b/pkg/operator/operands/admission/resources.go
@@ -397,7 +397,7 @@ func buildArgsList(kaiConfig *kaiv1.Config, config *kaiv1admission.Admission) []
 		args = append(args, "--gpu-pod-runtime-class-name", *config.GPUPodRuntimeClassName)
 	}
 
-	common.AddK8sClientConfigToArgs(config.Service.K8sClientConfig, args)
+	args = common.AddK8sClientConfigToArgs(config.Service.K8sClientConfig, args)
 	return common.AddControllerRuntimeJSONLogArg(kaiConfig.Spec.Global.JSONLog, args)
 }
 

--- a/pkg/operator/operands/admission/resources_test.go
+++ b/pkg/operator/operands/admission/resources_test.go
@@ -55,6 +55,8 @@ func TestDeploymentForKAIConfig(t *testing.T) {
 				"--webhook-addr", "9443",
 				"--health-probe-bind-address", ":8081",
 				"--metrics-bind-address", ":8080",
+				"--qps", "20",
+				"--burst", "100",
 			},
 			notExpectedArgs: []string{
 				"--gpu-sharing-enabled=true",

--- a/pkg/operator/operands/common/common.go
+++ b/pkg/operator/operands/common/common.go
@@ -323,7 +323,7 @@ func isControllerAvailable(obj client.Object, objKind string) (bool, error) {
 	return false, nil
 }
 
-func AddK8sClientConfigToArgs(k8sClientConfig *kaiv1common.K8sClientConfig, args []string) {
+func AddK8sClientConfigToArgs(k8sClientConfig *kaiv1common.K8sClientConfig, args []string) []string {
 	if k8sClientConfig != nil {
 		if k8sClientConfig.QPS != nil {
 			args = append(args, "--qps", strconv.Itoa(*k8sClientConfig.QPS))
@@ -332,6 +332,8 @@ func AddK8sClientConfigToArgs(k8sClientConfig *kaiv1common.K8sClientConfig, args
 			args = append(args, "--burst", strconv.Itoa(*k8sClientConfig.Burst))
 		}
 	}
+
+	return args
 }
 
 func AddControllerRuntimeJSONLogArg(jsonLog *bool, args []string) []string {

--- a/pkg/operator/operands/pod_group_controller/pod_group_controller_test.go
+++ b/pkg/operator/operands/pod_group_controller/pod_group_controller_test.go
@@ -53,6 +53,9 @@ var _ = Describe("PodGrouper", func() {
 				deployment := *deploymentT
 				Expect(deployment).NotTo(BeNil())
 				Expect(deployment.Name).To(Equal(defaultResourceName))
+				Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
+					"--qps", "20", "--burst", "100",
+				))
 			})
 
 			It("the deployment should keep labels from existing deployment", func(ctx context.Context) {

--- a/pkg/operator/operands/pod_group_controller/resources.go
+++ b/pkg/operator/operands/pod_group_controller/resources.go
@@ -228,7 +228,7 @@ func buildArgsList(config *pod_group_controller.PodGroupController, schedulerNam
 		"--scheduler-name", schedulerName,
 	}
 
-	common.AddK8sClientConfigToArgs(config.Service.K8sClientConfig, args)
+	args = common.AddK8sClientConfigToArgs(config.Service.K8sClientConfig, args)
 
 	if config.MaxConcurrentReconciles != nil {
 		args = append(args, "--max-concurrent-reconciles", strconv.Itoa(*config.MaxConcurrentReconciles))

--- a/pkg/operator/operands/queue_controller/queue_controller_test.go
+++ b/pkg/operator/operands/queue_controller/queue_controller_test.go
@@ -51,6 +51,9 @@ var _ = Describe("QueueController", func() {
 
 		Context("Deployment", func() {
 			It("should return a Deployment in the objects list", func(ctx context.Context) {
+				kaiConfig.Spec.QueueController.Service.K8sClientConfig.QPS = ptr.To(42)
+				kaiConfig.Spec.QueueController.Service.K8sClientConfig.Burst = ptr.To(84)
+
 				objects, err := qc.DesiredState(ctx, fakeKubeClient, kaiConfig)
 				Expect(err).To(BeNil())
 				Expect(len(objects)).To(BeNumerically(">", 1))
@@ -60,6 +63,9 @@ var _ = Describe("QueueController", func() {
 				deployment := *deploymentT
 				Expect(deployment).NotTo(BeNil())
 				Expect(deployment.Name).To(Equal(defaultResourceName))
+				Expect(deployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements(
+					"--qps", "42", "--burst", "84",
+				))
 			})
 
 			It("the deployment should keep labels from existing deployment", func(ctx context.Context) {

--- a/pkg/operator/operands/queue_controller/resources.go
+++ b/pkg/operator/operands/queue_controller/resources.go
@@ -274,6 +274,6 @@ func buildArgsList(kaiConfig *kaiv1.Config) []string {
 		args = append(args, "--queue-label-to-default-metric-value", *config.QueueLabelToDefaultMetricValue)
 	}
 
-	common.AddK8sClientConfigToArgs(config.Service.K8sClientConfig, args)
+	args = common.AddK8sClientConfigToArgs(config.Service.K8sClientConfig, args)
 	return common.AddControllerRuntimeJSONLogArg(kaiConfig.Spec.Global.JSONLog, args)
 }


### PR DESCRIPTION
# Description
Backport of #2027 to `v0.16`.