### PR TITLE
fix(scheduler): fail fast when feature gate discovery fails

### DIFF
--- a/.changes/unreleased/fixed-20260810-172251.yaml
+++ b/.changes/unreleased/fixed-20260810-172251.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: |-
+  Scheduler and binder now fail fast when Kubernetes API discovery fails at startup, instead of silently disabling dynamic resource allocation and node resource topology for the lifetime of the process.
+custom:
+  Issue: "2038"
+  Author: hcnguyen-ai

--- a/cmd/binder/app/app.go
+++ b/cmd/binder/app/app.go
@@ -105,7 +105,10 @@ func New(options *Options, config *rest.Config) (*App, error) {
 	kubeClient := draversionawareclient.NewDRAAwareClient(kubernetes.NewForConfigOrDie(config))
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 
-	featuregates.SetDRAFeatureGate(kubeClient.Discovery())
+	if err := featuregates.SetDRAFeatureGate(kubeClient.Discovery()); err != nil {
+		setupLog.Error(err, "unable to determine dynamic resource allocation availability")
+		return nil, err
+	}
 
 	rrs := resourcereservation.NewService(options.FakeGPUNodes, clientWithWatch, options.ResourceReservationPodImage,
 		time.Duration(options.ResourceReservationAllocationTimeout)*time.Second,

--- a/cmd/snapshot-tool/main.go
+++ b/cmd/snapshot-tool/main.go
@@ -93,7 +93,10 @@ func main() {
 		DiscoveryClient:             kubeClient.Discovery(),
 	}
 
-	schedulerCache := cache.New(schedulerCacheParams)
+	schedulerCache, err := cache.New(schedulerCacheParams)
+	if err != nil {
+		log.InfraLogger.Fatalf("Failed to create scheduler cache: %v", err)
+	}
 	stopCh := make(chan struct{})
 	schedulerCache.Run(stopCh)
 	schedulerCache.WaitForCacheSync(stopCh)

--- a/pkg/common/feature_gates/feature_gates.go
+++ b/pkg/common/feature_gates/feature_gates.go
@@ -27,9 +27,6 @@ const (
 // off to reflect server-side DRA availability.
 var dynamicResourcesEnabled atomic.Bool
 
-// SetDRAFeatureGate returns an error if DRA availability could not be determined.
-// Callers must treat that as fatal: the gate is evaluated once per process, so
-// defaulting to disabled would silently reject every DRA workload until restart.
 func SetDRAFeatureGate(discoveryClient discovery.DiscoveryInterface) error {
 	enabled, err := IsDynamicResourcesEnabled(discoveryClient)
 	if err != nil {
@@ -55,8 +52,6 @@ func SetDynamicResourcesEnabledForTest(enabled bool) {
 
 var nodeResourceTopologyEnabled atomic.Bool
 
-// SetNodeResourceTopologyFeatureGate returns an error if availability could not be
-// determined; see SetDRAFeatureGate for why callers must treat that as fatal.
 func SetNodeResourceTopologyFeatureGate(discoveryClient discovery.DiscoveryInterface) error {
 	enabled, err := IsNodeResourceTopologyEnabled(discoveryClient)
 	if err != nil {
@@ -75,8 +70,7 @@ func SetNodeResourceTopologyEnabledForTest(enabled bool) {
 }
 
 // IsNodeResourceTopologyEnabled reports whether the cluster serves the
-// topology.node.k8s.io API group (the NodeResourceTopology CRD). A discovery
-// failure is returned as an error rather than reported as "not served".
+// topology.node.k8s.io API group (the NodeResourceTopology CRD).
 func IsNodeResourceTopologyEnabled(discoveryClient discovery.DiscoveryInterface) (bool, error) {
 	serverGroups, err := discoveryClient.ServerGroups()
 	if err != nil {
@@ -91,8 +85,6 @@ func IsNodeResourceTopologyEnabled(discoveryClient discovery.DiscoveryInterface)
 	return false, nil
 }
 
-// IsDynamicResourcesEnabled reports whether the cluster supports DRA. A discovery
-// failure is returned as an error rather than reported as "not supported".
 func IsDynamicResourcesEnabled(discoveryClient discovery.DiscoveryInterface) (bool, error) {
 	// Get API server version
 	serverVersion, err := discoveryClient.ServerVersion()

--- a/pkg/common/feature_gates/feature_gates.go
+++ b/pkg/common/feature_gates/feature_gates.go
@@ -4,6 +4,7 @@
 package featuregates
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -11,7 +12,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	discovery "k8s.io/client-go/discovery"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -27,8 +27,16 @@ const (
 // off to reflect server-side DRA availability.
 var dynamicResourcesEnabled atomic.Bool
 
-func SetDRAFeatureGate(discoveryClient discovery.DiscoveryInterface) {
-	dynamicResourcesEnabled.Store(IsDynamicResourcesEnabled(discoveryClient))
+// SetDRAFeatureGate returns an error if DRA availability could not be determined.
+// Callers must treat that as fatal: the gate is evaluated once per process, so
+// defaulting to disabled would silently reject every DRA workload until restart.
+func SetDRAFeatureGate(discoveryClient discovery.DiscoveryInterface) error {
+	enabled, err := IsDynamicResourcesEnabled(discoveryClient)
+	if err != nil {
+		return err
+	}
+	dynamicResourcesEnabled.Store(enabled)
+	return nil
 }
 
 // DynamicResourcesEnabled reports whether DRA was determined to be usable
@@ -47,8 +55,15 @@ func SetDynamicResourcesEnabledForTest(enabled bool) {
 
 var nodeResourceTopologyEnabled atomic.Bool
 
-func SetNodeResourceTopologyFeatureGate(discoveryClient discovery.DiscoveryInterface) {
-	nodeResourceTopologyEnabled.Store(IsNodeResourceTopologyEnabled(discoveryClient))
+// SetNodeResourceTopologyFeatureGate returns an error if availability could not be
+// determined; see SetDRAFeatureGate for why callers must treat that as fatal.
+func SetNodeResourceTopologyFeatureGate(discoveryClient discovery.DiscoveryInterface) error {
+	enabled, err := IsNodeResourceTopologyEnabled(discoveryClient)
+	if err != nil {
+		return err
+	}
+	nodeResourceTopologyEnabled.Store(enabled)
+	return nil
 }
 
 func NodeResourceTopologyEnabled() bool {
@@ -60,44 +75,40 @@ func SetNodeResourceTopologyEnabledForTest(enabled bool) {
 }
 
 // IsNodeResourceTopologyEnabled reports whether the cluster serves the
-// topology.node.k8s.io API group (the NodeResourceTopology CRD).
-func IsNodeResourceTopologyEnabled(discoveryClient discovery.DiscoveryInterface) bool {
-	logger := log.Log.WithName("feature-gates")
-
+// topology.node.k8s.io API group (the NodeResourceTopology CRD). A discovery
+// failure is returned as an error rather than reported as "not served".
+func IsNodeResourceTopologyEnabled(discoveryClient discovery.DiscoveryInterface) (bool, error) {
 	serverGroups, err := discoveryClient.ServerGroups()
 	if err != nil {
-		logger.Error(err, "Failed to get server groups")
-		return false
+		return false, fmt.Errorf("failed to get server groups: %w", err)
 	}
 
 	for _, group := range serverGroups.Groups {
 		if group.Name == nodeResourceTopologyGroup {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func IsDynamicResourcesEnabled(discoveryClient discovery.DiscoveryInterface) bool {
-	logger := log.Log.WithName("feature-gates")
-
+// IsDynamicResourcesEnabled reports whether the cluster supports DRA. A discovery
+// failure is returned as an error rather than reported as "not supported".
+func IsDynamicResourcesEnabled(discoveryClient discovery.DiscoveryInterface) (bool, error) {
 	// Get API server version
 	serverVersion, err := discoveryClient.ServerVersion()
 	if err != nil {
-		logger.Error(err, "Failed to get server version")
-		return false
+		return false, fmt.Errorf("failed to get server version: %w", err)
 	}
 
 	// Check if the API server version is compatible with DRA
 	if !isCompatibleDRAVersion(serverVersion) {
-		return false
+		return false, nil
 	}
 
 	// Get supported API versions
 	serverGroups, err := discoveryClient.ServerGroups()
 	if err != nil {
-		logger.Error(err, "Failed to get server groups")
-		return false
+		return false, fmt.Errorf("failed to get server groups: %w", err)
 	}
 
 	found := false
@@ -110,17 +121,17 @@ func IsDynamicResourcesEnabled(discoveryClient discovery.DiscoveryInterface) boo
 		}
 	}
 	if !found {
-		return false
+		return false, nil
 	}
 
 	// Check if the DRA API group is supported
 	for _, groupVersion := range resourceGroup.Versions {
 		if version.CompareKubeAwareVersionStrings(groupVersion.Version, minimalSupportedVersion) >= 0 {
-			return true
+			return true, nil
 		}
 	}
 
-	return false
+	return false, nil
 }
 
 func isCompatibleDRAVersion(serverVersion *version.Info) bool {

--- a/pkg/common/feature_gates/feature_gates_test.go
+++ b/pkg/common/feature_gates/feature_gates_test.go
@@ -4,6 +4,7 @@
 package featuregates
 
 import (
+	"errors"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -13,9 +14,41 @@ import (
 	resourcev1beta1 "k8s.io/api/resource/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	version "k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/fake"
 )
+
+// erroringDiscovery fails the requested discovery call, standing in for an API
+// server that is briefly unreachable while a component starts up.
+type erroringDiscovery struct {
+	discovery.DiscoveryInterface
+	versionErr error
+	groupsErr  error
+}
+
+func (e *erroringDiscovery) ServerVersion() (*version.Info, error) {
+	if e.versionErr != nil {
+		return nil, e.versionErr
+	}
+	return e.DiscoveryInterface.ServerVersion()
+}
+
+func (e *erroringDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	if e.groupsErr != nil {
+		return nil, e.groupsErr
+	}
+	return e.DiscoveryInterface.ServerGroups()
+}
+
+func discoveryForVersion(major, minor string) discovery.DiscoveryInterface {
+	fakeClient := fake.NewClientset()
+	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		Major: major,
+		Minor: minor,
+	}
+	return fakeClient.Discovery()
+}
 
 func TestCache(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -46,5 +79,75 @@ var _ = Describe("New", func() {
 			Entry("edge case version (1.31) with resource API should not enable DRA", "1", "31", []string{resourcev1alhpa3.SchemeGroupVersion.String()}, false),
 			Entry("higher compatible version (1.35) with resource API should enable DRA", "1", "34", []string{resourcev1.SchemeGroupVersion.String()}, true),
 		)
+
+		It("should return an error when the server version cannot be retrieved", func() {
+			discoveryClient := &erroringDiscovery{
+				DiscoveryInterface: discoveryForVersion("1", "34"),
+				versionErr:         errors.New("connection refused"),
+			}
+
+			_, err := IsDynamicResourcesEnabled(discoveryClient)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return an error when the server groups cannot be retrieved", func() {
+			discoveryClient := &erroringDiscovery{
+				DiscoveryInterface: discoveryForVersion("1", "34"),
+				groupsErr:          errors.New("connection refused"),
+			}
+
+			_, err := IsDynamicResourcesEnabled(discoveryClient)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should leave the gate untouched when discovery fails", func() {
+			SetDynamicResourcesEnabledForTest(true)
+			DeferCleanup(SetDynamicResourcesEnabledForTest, false)
+
+			discoveryClient := &erroringDiscovery{
+				DiscoveryInterface: discoveryForVersion("1", "34"),
+				versionErr:         errors.New("connection refused"),
+			}
+
+			Expect(SetDRAFeatureGate(discoveryClient)).NotTo(Succeed())
+			Expect(DynamicResourcesEnabled()).To(BeTrue())
+		})
+	})
+
+	Context("NodeResourceTopology Feature Gate", func() {
+		It("should report availability when the API group is served", func() {
+			fakeClient := fake.NewClientset()
+			fakeClient.Resources = append(fakeClient.Resources,
+				&metav1.APIResourceList{GroupVersion: nodeResourceTopologyGroup + "/v1alpha2"})
+
+			Expect(IsNodeResourceTopologyEnabled(fakeClient.Discovery())).To(BeTrue())
+		})
+
+		It("should report unavailability when the API group is absent", func() {
+			Expect(IsNodeResourceTopologyEnabled(fake.NewClientset().Discovery())).To(BeFalse())
+		})
+
+		It("should return an error when the server groups cannot be retrieved", func() {
+			discoveryClient := &erroringDiscovery{
+				DiscoveryInterface: fake.NewClientset().Discovery(),
+				groupsErr:          errors.New("connection refused"),
+			}
+
+			_, err := IsNodeResourceTopologyEnabled(discoveryClient)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should leave the gate untouched when discovery fails", func() {
+			SetNodeResourceTopologyEnabledForTest(true)
+			DeferCleanup(SetNodeResourceTopologyEnabledForTest, false)
+
+			discoveryClient := &erroringDiscovery{
+				DiscoveryInterface: fake.NewClientset().Discovery(),
+				groupsErr:          errors.New("connection refused"),
+			}
+
+			Expect(SetNodeResourceTopologyFeatureGate(discoveryClient)).NotTo(Succeed())
+			Expect(NodeResourceTopologyEnabled()).To(BeTrue())
+		})
 	})
 })

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -113,7 +113,7 @@ func registerSchedulerPodInformer(informerFactory informers.SharedInformerFactor
 }
 
 // New returns a Cache implementation.
-func New(schedulerCacheParams *SchedulerCacheParams) Cache {
+func New(schedulerCacheParams *SchedulerCacheParams) (Cache, error) {
 	return newSchedulerCache(schedulerCacheParams)
 }
 
@@ -164,7 +164,7 @@ type SchedulerCache struct {
 	K8sClusterPodAffinityInfo
 }
 
-func newSchedulerCache(schedulerCacheParams *SchedulerCacheParams) *SchedulerCache {
+func newSchedulerCache(schedulerCacheParams *SchedulerCacheParams) (*SchedulerCache, error) {
 	sc := &SchedulerCache{
 		schedulingNodePoolParams:  schedulerCacheParams.NodePoolParams,
 		restrictNodeScheduling:    schedulerCacheParams.RestrictNodeScheduling,
@@ -196,13 +196,16 @@ func newSchedulerCache(schedulerCacheParams *SchedulerCacheParams) *SchedulerCac
 	sc.informerFactory = informers.NewSharedInformerFactory(sc.kubeClient, 0)
 	registerSchedulerPodInformer(sc.informerFactory)
 	if err := setSchedulerPodTransform(sc.informerFactory.Core().V1().Pods().Informer()); err != nil {
-		log.InfraLogger.Errorf("Failed to set scheduler pod transform: %v", err)
-		return nil
+		return nil, fmt.Errorf("failed to set scheduler pod transform: %w", err)
 	}
 	sc.kubeAiSchedulerInformerFactory = kubeaischedulerinfo.NewSharedInformerFactory(sc.kubeAiSchedulerClient, 0)
 
-	featuregates.SetDRAFeatureGate(schedulerCacheParams.DiscoveryClient)
-	featuregates.SetNodeResourceTopologyFeatureGate(schedulerCacheParams.DiscoveryClient)
+	if err := featuregates.SetDRAFeatureGate(schedulerCacheParams.DiscoveryClient); err != nil {
+		return nil, fmt.Errorf("failed to determine dynamic resource allocation availability: %w", err)
+	}
+	if err := featuregates.SetNodeResourceTopologyFeatureGate(schedulerCacheParams.DiscoveryClient); err != nil {
+		return nil, fmt.Errorf("failed to determine node resource topology availability: %w", err)
+	}
 	if featuregates.NodeResourceTopologyEnabled() && schedulerCacheParams.NRTClient != nil {
 		sc.nrtInformerFactory = nrtinformers.NewSharedInformerFactory(schedulerCacheParams.NRTClient, 0)
 	}
@@ -223,12 +226,11 @@ func newSchedulerCache(schedulerCacheParams *SchedulerCacheParams) *SchedulerCac
 		sc.restrictNodeScheduling, &sc.K8sClusterPodAffinityInfo, sc.scheduleCSIStorage, sc.fullHierarchyFairness, sc.StatusUpdater, sc.stuckInReleasingThreshold)
 
 	if err != nil {
-		log.InfraLogger.Errorf("Failed to create cluster info object: %v", err)
-		return nil
+		return nil, fmt.Errorf("failed to create cluster info object: %w", err)
 	}
 	sc.clusterInfo = clusterInfo
 
-	return sc
+	return sc, nil
 }
 
 func (sc *SchedulerCache) Snapshot() (*api.ClusterInfo, error) {

--- a/pkg/scheduler/cache/cache_test.go
+++ b/pkg/scheduler/cache/cache_test.go
@@ -60,12 +60,13 @@ var _ = Describe("Cache", func() {
 		Context("Pod informer filtering", func() {
 			It("should filter failed pods while keeping succeeded pods, without filtering by scheduler name", func() {
 				kubeClient := fake.NewSimpleClientset()
-				cache := New(&SchedulerCacheParams{
+				cache, err := New(&SchedulerCacheParams{
 					KubeClient:         kubeClient,
 					KAISchedulerClient: kubeaischedulerfake.NewSimpleClientset(),
 					NodePoolParams:     &conf.SchedulingNodePoolParams{},
 					DiscoveryClient:    kubeClient.Discovery(),
 				})
+				Expect(err).NotTo(HaveOccurred())
 
 				stopCh := make(chan struct{})
 				defer close(stopCh)
@@ -123,8 +124,9 @@ var _ = Describe("Cache", func() {
 						DiscoveryClient:    fakeClient.Discovery(),
 					}
 
-					cache := New(params)
+					cache, err := New(params)
 
+					Expect(err).NotTo(HaveOccurred())
 					Expect(cache).NotTo(BeNil())
 					Expect(featuregates.DynamicResourcesEnabled()).To(Equal(expectDRAAvailable))
 				},
@@ -515,13 +517,14 @@ func setupCacheWithObjects(snapshot bool, objects []runtime.Object, kaiScheduler
 	kubeClient := fake.NewSimpleClientset(objects...)
 	kubeAiSchedulerClient := kubeaischedulerfake.NewSimpleClientset(kaiSchedulerObjects...)
 
-	cache := New(&SchedulerCacheParams{
+	cache, err := New(&SchedulerCacheParams{
 		KubeClient:            kubeClient,
 		KAISchedulerClient:    kubeAiSchedulerClient,
 		NodePoolParams:        &conf.SchedulingNodePoolParams{},
 		FullHierarchyFairness: true,
 		DiscoveryClient:       kubeClient.Discovery(),
 	})
+	Expect(err).NotTo(HaveOccurred())
 
 	stopCh := make(chan struct{})
 	cache.Run(stopCh)

--- a/pkg/scheduler/cache/record_job_status_event_test.go
+++ b/pkg/scheduler/cache/record_job_status_event_test.go
@@ -334,7 +334,7 @@ func TestRecordJobStatusEvent(t *testing.T) {
 				detailedFitErrors = *tt.detailedErrors
 			}
 
-			cache := New(&SchedulerCacheParams{
+			cache, err := New(&SchedulerCacheParams{
 				KubeClient:                  kubeClient,
 				KAISchedulerClient:          kubeAiSchedulerClient,
 				NodePoolParams:              &conf.SchedulingNodePoolParams{},
@@ -343,6 +343,7 @@ func TestRecordJobStatusEvent(t *testing.T) {
 				NumOfStatusRecordingWorkers: 4,
 				DiscoveryClient:             kubeClient.Discovery(),
 			})
+			assert.Nil(t, err)
 
 			stopCh := make(chan struct{})
 			cache.Run(stopCh)
@@ -371,7 +372,7 @@ func TestRecordJobStatusEvent(t *testing.T) {
 				podGroupInfo.AddSimpleJobFitError(explanation.Reason, explanation.Message)
 			}
 
-			err := cache.RecordJobStatusEvent(podGroupInfo, nil)
+			err = cache.RecordJobStatusEvent(podGroupInfo, nil)
 			assert.Nil(t, err)
 
 			newPodGroupObj, err := waitForCondition(func() (runtime.Object, error) {
@@ -498,7 +499,7 @@ func TestRecordJobStatusEventInvalidSubGroupPod(t *testing.T) {
 
 	kubeClient := fake.NewSimpleClientset(validPod, invalidPod)
 	kubeAiSchedulerClient := kubeaischedulerfake.NewSimpleClientset(podGroup)
-	cache := New(&SchedulerCacheParams{
+	cache, err := New(&SchedulerCacheParams{
 		KubeClient:                  kubeClient,
 		KAISchedulerClient:          kubeAiSchedulerClient,
 		NodePoolParams:              &conf.SchedulingNodePoolParams{},
@@ -507,6 +508,7 @@ func TestRecordJobStatusEventInvalidSubGroupPod(t *testing.T) {
 		NumOfStatusRecordingWorkers: 4,
 		DiscoveryClient:             kubeClient.Discovery(),
 	})
+	assert.Nil(t, err)
 
 	stopCh := make(chan struct{})
 	cache.Run(stopCh)
@@ -519,7 +521,7 @@ func TestRecordJobStatusEventInvalidSubGroupPod(t *testing.T) {
 	job.AddTaskInfo(pod_info.NewTaskInfo(validPod, vectorMap))
 	job.AddTaskInfo(pod_info.NewTaskInfo(invalidPod, vectorMap))
 
-	err := cache.RecordJobStatusEvent(job, nil)
+	err = cache.RecordJobStatusEvent(job, nil)
 	assert.NoError(t, err)
 
 	invalidPodObj, err := waitForCondition(func() (runtime.Object, error) {

--- a/pkg/scheduler/plugins/snapshot/snapshot_test.go
+++ b/pkg/scheduler/plugins/snapshot/snapshot_test.go
@@ -157,7 +157,7 @@ func TestSnapshotPlugin(t *testing.T) {
 		},
 	}
 
-	schedulerCache := cache.New(&cache.SchedulerCacheParams{
+	schedulerCache, cacheErr := cache.New(&cache.SchedulerCacheParams{
 		KubeClient:                  fakeKubeClient,
 		KAISchedulerClient:          fakeKubeAISchedulerClient,
 		SchedulerName:               schedulerParams.SchedulerName,
@@ -169,6 +169,7 @@ func TestSnapshotPlugin(t *testing.T) {
 		NumOfStatusRecordingWorkers: 1,
 		DiscoveryClient:             fakeKubeClient.Discovery(),
 	})
+	assert.NoError(t, cacheErr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/scheduler/plugins/topology/topology_plugin_test.go
+++ b/pkg/scheduler/plugins/topology/topology_plugin_test.go
@@ -121,7 +121,7 @@ func TestTopologyPlugin_initializeTopologyTree(t *testing.T) {
 		PartitionParams: &conf.SchedulingNodePoolParams{},
 	}
 
-	schedulerCache := cache.New(&cache.SchedulerCacheParams{
+	schedulerCache, cacheErr := cache.New(&cache.SchedulerCacheParams{
 		KubeClient:                  fakeKubeClient,
 		KAISchedulerClient:          fakeKubeAISchedulerClient,
 		SchedulerName:               schedulerParams.SchedulerName,
@@ -133,6 +133,7 @@ func TestTopologyPlugin_initializeTopologyTree(t *testing.T) {
 		NumOfStatusRecordingWorkers: 1,
 		DiscoveryClient:             fakeKubeClient.Discovery(),
 	})
+	assert.NoError(t, cacheErr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -97,10 +97,15 @@ func NewScheduler(
 		DiscoveryClient:             discoveryClient,
 	}
 
+	schedulerCache, err := schedcache.New(schedulerCacheParams)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create scheduler cache: %v", err)
+	}
+
 	scheduler := &Scheduler{
 		config:          schedulerConf,
 		schedulerParams: schedulerParams,
-		cache:           schedcache.New(schedulerCacheParams),
+		cache:           schedulerCache,
 		schedulePeriod:  schedulerParams.SchedulePeriod,
 		mux:             mux,
 	}


### PR DESCRIPTION
Fixes #2038.

## What

Both feature gates derive their value from a single discovery call at process startup, and treat *any* error from that call as "the cluster does not support this feature":

```go
serverVersion, err := discoveryClient.ServerVersion()
if err != nil {
	logger.Error(err, "Failed to get server version")
	return false
}
```

The result is stored in a package-level `atomic.Bool` with no retry and no re-evaluation, so a transient API server error — a restart, a rolling control-plane upgrade, a brief network partition — is indistinguishable from the API group genuinely being absent, and the process stays with the feature disabled for its entire lifetime.

In our case a ~5 minute API server outage caught one scheduler replica at startup. It latched DRA off, won the leader lease, and rejected every pod carrying a ResourceClaim for over two hours while reporting healthy, on a cluster where DRA was fully functional.

## Change

`IsDynamicResourcesEnabled` and `IsNodeResourceTopologyEnabled` now return `(bool, error)`. A discovery failure is returned as an error; `(false, nil)` is reserved for the feature genuinely not being served. `SetDRAFeatureGate` and `SetNodeResourceTopologyFeatureGate` return that error and **leave the stored gate untouched on failure**, so a failed call can never silently flip a gate off.

Callers treat it as fatal, per the discussion in #2038 — a component that cannot determine feature availability at startup exits non-zero and crashloops visibly, rather than running degraded. It also self-corrects once the API server recovers.

Propagated through:

- `pkg/scheduler/cache/cache.go` — `New` and `newSchedulerCache` now return an error
- `pkg/scheduler/scheduler.go` and `cmd/snapshot-tool/main.go` — the two `cache.New` callers
- `cmd/binder/app/app.go`

The NodeResourceTopology gate is included because it has the same defect, as noted in the issue discussion.

Incidentally, `newSchedulerCache` already had two failure paths that logged and returned `nil` while callers dereferenced the result. Returning an error removes those latent nil dereferences.

The `ctrl.SetLogger` fix for `cmd/scheduler` — which is why the original error was never logged — is left for a separate PR as requested.

## Tests

New coverage in `pkg/common/feature_gates/feature_gates_test.go`:

- an error is returned when `ServerVersion` or `ServerGroups` fails, for both gates
- a failed `Set*FeatureGate` leaves the previously stored value unchanged
- first direct coverage of `IsNodeResourceTopologyEnabled` for the served / not-served cases

A small `erroringDiscovery` wrapper stands in for an unreachable API server, rather than depending on fake-client internals.

Existing call sites updated for the new signatures.

## Verification

- `go build ./...`, `go vet ./pkg/... ./cmd/...`, `gofmt -l ./pkg ./cmd` — all clean
- `go test ./pkg/...` — 169 packages pass. Four envtest-based packages (`binder/controllers/integration_tests`, `env-tests`, `operator/controller/integration_tests`, `queuecontroller/controllers`) fail in `BeforeSuite` with `fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory`, i.e. `KUBEBUILDER_ASSETS` is not set up in my environment. They fail before any changed code runs.
