### PR TITLE
Fix(clusterRole): - Remove ConfigMap access entirely from `kai-admission`, `queuecontroller`, `kai-podgroup-controller`, and `kai-node-scale-adjuster`

### DIFF
--- a/.changes/unreleased/Fixed-20260811-233307.yaml
+++ b/.changes/unreleased/Fixed-20260811-233307.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: tighten configmap verb for admission, nodescaleadjuster, podgroupcontroller, podgrouper, queuecontroller, scheduler ClusterRole
+time: 2026-08-11T23:33:07.93807465+01:00
+custom:
+    Author: dttung2905
+    Issue: "2060"

--- a/cmd/admission/app/app.go
+++ b/cmd/admission/app/app.go
@@ -140,7 +140,6 @@ func (app *App) RegisterPlugins(admissionPlugins *admissionplugins.KaiAdmissionP
 	app.admissionPlugins = admissionPlugins
 }
 
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch;update
 

--- a/cmd/nodescaleadjuster/app/app.go
+++ b/cmd/nodescaleadjuster/app/app.go
@@ -33,7 +33,6 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch;update
 

--- a/cmd/podgroupcontroller/app/app.go
+++ b/cmd/podgroupcontroller/app/app.go
@@ -48,7 +48,6 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 func Run(options *Options, config *rest.Config, ctx context.Context) error {

--- a/cmd/podgrouper/app/app.go
+++ b/cmd/podgrouper/app/app.go
@@ -134,7 +134,6 @@ func (app *App) RegisterPlugins(pluginsHub pluginshub.PluginsHub) {
 	app.pluginsHub = pluginsHub
 }
 
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 func (app *App) Run() error {

--- a/cmd/queuecontroller/app/app.go
+++ b/cmd/queuecontroller/app/app.go
@@ -43,7 +43,6 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 func Run(opts *Options, clientConfig *rest.Config, ctx context.Context) error {

--- a/cmd/scheduler/app/server.go
+++ b/cmd/scheduler/app/server.go
@@ -180,7 +180,6 @@ func setConfig(so *options.ServerOption) {
 	config.MIGWorkerNodeLabelKey = so.MIGWorkerNodeLabelKey
 }
 
-// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 
 func Run(ctx context.Context, opt *options.ServerOption, config *restclient.Config, mux *http.ServeMux) error {

--- a/deployments/kai-scheduler/templates/rbac/admission.yaml
+++ b/deployments/kai-scheduler/templates/rbac/admission.yaml
@@ -13,18 +13,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create

--- a/deployments/kai-scheduler/templates/rbac/nodescaleadjuster.yaml
+++ b/deployments/kai-scheduler/templates/rbac/nodescaleadjuster.yaml
@@ -13,7 +13,15 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
+  - events
+  - pods/finalizers
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - create
@@ -23,15 +31,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - events
-  - pods/finalizers
-  verbs:
-  - create
-  - patch
-  - update
 - apiGroups:
   - ""
   resources:

--- a/deployments/kai-scheduler/templates/rbac/podgroupcontroller.yaml
+++ b/deployments/kai-scheduler/templates/rbac/podgroupcontroller.yaml
@@ -13,18 +13,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - nodes
   - pods
   - pods/status

--- a/deployments/kai-scheduler/templates/rbac/podgrouper.yaml
+++ b/deployments/kai-scheduler/templates/rbac/podgrouper.yaml
@@ -14,13 +14,10 @@ rules:
   - ""
   resources:
   - configmaps
+  - namespaces
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - ""
@@ -33,14 +30,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - ""

--- a/deployments/kai-scheduler/templates/rbac/queuecontroller.yaml
+++ b/deployments/kai-scheduler/templates/rbac/queuecontroller.yaml
@@ -11,18 +11,6 @@ metadata:
   name: queuecontroller
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/deployments/kai-scheduler/templates/rbac/scheduler.yaml
+++ b/deployments/kai-scheduler/templates/rbac/scheduler.yaml
@@ -14,6 +14,17 @@ rules:
   - ""
   resources:
   - configmaps
+  - namespaces
+  - nodes
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   - pods/status
   verbs:
@@ -23,17 +34,6 @@ rules:
   - list
   - patch
   - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  - nodes
-  - persistentvolumeclaims
-  - persistentvolumes
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - ""


### PR DESCRIPTION

## Description

Remove ConfigMap access entirely from `kai-admission`, `queuecontroller`, `kai-podgroup-controller`, and `kai-node-scale-adjuster` (they never use the ConfigMap API; current full CRUD is leftover leader-election scaffolding). (they never use the ConfigMap API; current full CRUD is leftover leader-election scaffolding).

## Related Issues

Fixes https://github.com/kai-scheduler/KAI-Scheduler/issues/2060

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
