### PR TITLE
refactor(admission): remove unused binder reconciler params

### DIFF
--- a/cmd/admission/app/app.go
+++ b/cmd/admission/app/app.go
@@ -33,7 +33,6 @@ import (
 
 	admissionplugins "github.com/kai-scheduler/KAI-scheduler/pkg/admission/plugins"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/admission/webhook/topologyhooks"
-	"github.com/kai-scheduler/KAI-scheduler/pkg/binder/controllers"
 )
 
 var (
@@ -54,7 +53,6 @@ type App struct {
 	InformerFactory  informers.SharedInformerFactory
 	Options          *Options
 	manager          manager.Manager
-	reconcilerParams *controllers.ReconcilerParams
 	admissionPlugins *admissionplugins.KaiAdmissionPlugins
 }
 
@@ -120,18 +118,12 @@ func New() (*App, error) {
 	kubeClient := kubernetes.NewForConfigOrDie(config)
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 
-	reconcilerParams := &controllers.ReconcilerParams{
-		RateLimiterBaseDelaySeconds: options.RateLimiterBaseDelaySeconds,
-		RateLimiterMaxDelaySeconds:  options.RateLimiterMaxDelaySeconds,
-	}
-
 	app := &App{
-		K8sInterface:     kubeClient,
-		Client:           clientWithWatch,
-		InformerFactory:  informerFactory,
-		Options:          options,
-		manager:          mgr,
-		reconcilerParams: reconcilerParams,
+		K8sInterface:    kubeClient,
+		Client:          clientWithWatch,
+		InformerFactory: informerFactory,
+		Options:         options,
+		manager:         mgr,
 	}
 	return app, nil
 }

--- a/cmd/admission/app/options.go
+++ b/cmd/admission/app/options.go
@@ -16,8 +16,6 @@ type Options struct {
 	SchedulerName               string
 	QPS                         float64
 	Burst                       int
-	RateLimiterBaseDelaySeconds int
-	RateLimiterMaxDelaySeconds  int
 	EnableLeaderElection        bool
 	MetricsAddr                 string
 	ProbeAddr                   string
@@ -57,12 +55,6 @@ func InitOptions() *Options {
 	fs.IntVar(&options.Burst,
 		"burst", 300,
 		"Burst to the K8s API server")
-	fs.IntVar(&options.RateLimiterBaseDelaySeconds,
-		"rate-limiter-base-delay", 1,
-		"Base delay in seconds for the ExponentialFailureRateLimiter")
-	fs.IntVar(&options.RateLimiterMaxDelaySeconds,
-		"rate-limiter-max-delay", 60,
-		"Max delay in seconds for the ExponentialFailureRateLimiter")
 	fs.BoolVar(&options.EnableLeaderElection,
 		"leader-elect", false,
 		"Enable leader election for controller manager. "+


### PR DESCRIPTION
## Description

The admission `App` struct held a `reconcilerParams *controllers.ReconcilerParams` field that was populated in `New()` but never read — no binder reconciler is registered with admission's manager. This needlessly pulled `pkg/binder/controllers` into the admission binary.

Removes the field, its assignment, the import, and the now-unused `RateLimiterBaseDelaySeconds`/`RateLimiterMaxDelaySeconds` options along with their `--rate-limiter-base-delay`/`--rate-limiter-max-delay` flags. Nothing in-repo (operator, Helm chart, tests) passes those flags to the admission binary.

## Related Issues

Fixes #2062

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None in practice — the removed flags were dead options (parsed but never used). Passing `--rate-limiter-base-delay`/`--rate-limiter-max-delay` to the admission binary would now fail with an unknown-flag error.

## Additional Notes

`make validate` passes: no generated-file diffs, golangci-lint reports 0 issues.