### PR TITLE
fix(chart): Render global.daemonsetsTolerations into kai-config

### DIFF
--- a/.changes/unreleased/Fixed-20260815-190234.yaml
+++ b/.changes/unreleased/Fixed-20260815-190234.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Render global.daemonsetsTolerations into kai-config
+time: 2026-08-15T19:02:34.96721934+01:00
+custom:
+    Author: dttung2905
+    Issue: ""

--- a/deployments/kai-scheduler/templates/_helpers.tpl
+++ b/deployments/kai-scheduler/templates/_helpers.tpl
@@ -87,6 +87,10 @@ spec:
     tolerations:
       {{- toYaml .Values.global.tolerations | nindent 6 }}
     {{- end }}
+    {{- if .Values.global.daemonsetsTolerations }}
+    daemonsetsTolerations:
+      {{- toYaml .Values.global.daemonsetsTolerations | nindent 6 }}
+    {{- end }}
     {{- if .Values.global.priorityClassName }}
     priorityClassName: {{ .Values.global.priorityClassName | quote }}
     {{- end }}

--- a/deployments/kai-scheduler/tests/numa_placement_exporter_test.yaml
+++ b/deployments/kai-scheduler/tests/numa_placement_exporter_test.yaml
@@ -48,3 +48,45 @@ tests:
       - equal:
           path: spec.numaPlacementExporter.tolerations[0].operator
           value: Exists
+
+  - it: should not render global.daemonsetsTolerations when the list is empty
+    asserts:
+      - notExists:
+          path: spec.global.daemonsetsTolerations
+
+  - it: should render global.daemonsetsTolerations onto spec.global
+    set:
+      global.daemonsetsTolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.global.daemonsetsTolerations[0].key
+          value: nvidia.com/gpu
+      - equal:
+          path: spec.global.daemonsetsTolerations[0].operator
+          value: Exists
+      - equal:
+          path: spec.global.daemonsetsTolerations[0].effect
+          value: NoSchedule
+
+  - it: should render global.daemonsetsTolerations independently of exporter tolerations
+    set:
+      global.daemonsetsTolerations:
+        - key: dedicated
+          operator: Equal
+          value: gpu
+          effect: NoSchedule
+      numaPlacementExporter.tolerations:
+        - operator: Exists
+    asserts:
+      - equal:
+          path: spec.global.daemonsetsTolerations[0].key
+          value: dedicated
+      - equal:
+          path: spec.global.daemonsetsTolerations[0].value
+          value: gpu
+      - equal:
+          path: spec.numaPlacementExporter.tolerations[0].operator
+          value: Exists

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -25,6 +25,9 @@ global:
   affinity: {}
   requireDefaultPodAntiAffinityTerm: false
   tolerations: []
+  # Additional tolerations for cluster DaemonSets (e.g. NUMA placement exporter).
+  # Merged ahead of each DaemonSet's own tolerations by the operator.
+  daemonsetsTolerations: []
   priorityClassName: ""
   namespaceLabelSelector: {}
   podLabelSelector: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

In this piece of code https://github.com/kai-scheduler/KAI-Scheduler/blob/cea080fe6f7674f669bea907c8a92b5edeaa31b7/deployments/kai-scheduler/values.yaml#L197-L205, it refers to `global.daemonsetsTolerations` but it is not wirted into kai-config. This PR fixes that

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
