### PR TITLE
fix(podgrouper): skip WorkloadRunner wrapper when selecting the grouping plugin (v0.16 backport)

### DIFF
--- a/.changes/unreleased/fixed-20260812-141030.yaml
+++ b/.changes/unreleased/fixed-20260812-141030.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Podgrouper skips WorkloadRunner wrapper so wrapped workloads keep their gang grouping

--- a/deployments/kai-scheduler/templates/rbac/podgrouper.yaml
+++ b/deployments/kai-scheduler/templates/rbac/podgrouper.yaml
@@ -265,6 +265,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - nvidia.com
+  resources:
+  - dynamographdeployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ray.io
   resources:
   - rayclusters
@@ -293,6 +301,7 @@ rules:
   - interactiveworkloads
   - runaijobs
   - trainingworkloads
+  - workloadrunners
   verbs:
   - get
   - list

--- a/pkg/podgrouper/podgrouper/hub/hub.go
+++ b/pkg/podgrouper/podgrouper/hub/hub.go
@@ -41,6 +41,7 @@ const (
 	kindDistributedWorkload          = "DistributedWorkload"
 	kindInferenceWorkload            = "InferenceWorkload"
 	kindDistributedInferenceWorkload = "DistributedInferenceWorkload"
+	kindWorkloadRunner               = "WorkloadRunner"
 )
 
 // +kubebuilder:rbac:groups=apps,resources=replicasets;statefulsets,verbs=get;list;watch
@@ -56,6 +57,8 @@ const (
 // +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns;taskruns,verbs=get;list;watch
 // +kubebuilder:rbac:groups=tekton.dev,resources=pipelineruns/finalizers;taskruns/finalizers,verbs=patch;update;create
 // +kubebuilder:rbac:groups=run.ai,resources=trainingworkloads;interactiveworkloads;distributedworkloads;inferenceworkloads;distributedinferenceworkloads,verbs=get;list;watch
+// +kubebuilder:rbac:groups=run.ai,resources=workloadrunners,verbs=get;list;watch
+// +kubebuilder:rbac:groups=nvidia.com,resources=dynamographdeployments,verbs=get;list;watch
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainjobs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainjobs/finalizers,verbs=patch;update;create
 
@@ -291,7 +294,18 @@ func NewDefaultPluginsHub(kubeClient client.Client, searchForLegacyPodGroups,
 		}: groveGrouper,
 	}
 
-	skipTopOwnerGrouper := skiptopowner.NewSkipTopOwnerGrouper(kubeClient, defaultGrouper, table)
+	hub := &DefaultPluginsHub{
+		defaultPlugin: defaultGrouper,
+		customPlugins: table,
+	}
+
+	// hub is captured by pointer and read only when the closure runs, so the skip
+	// grouper still sees the table entries assigned below.
+	skipTopOwnerGrouper := skiptopowner.NewSkipTopOwnerGrouper(kubeClient, defaultGrouper,
+		func(gvk metav1.GroupVersionKind) grouper.Grouper {
+			return hub.GetPodGrouperPlugin(gvk)
+		})
+
 	table[metav1.GroupVersionKind{
 		Group:   apiGroupArgo,
 		Version: "v1alpha1",
@@ -326,8 +340,13 @@ func NewDefaultPluginsHub(kubeClient client.Client, searchForLegacyPodGroups,
 		Kind:    "DynamoGraphDeployment",
 	}] = skipTopOwnerGrouper
 
-	return &DefaultPluginsHub{
-		defaultPlugin: defaultGrouper,
-		customPlugins: table,
-	}
+	// WorkloadRunner is a kind-agnostic wrapper around an arbitrary workload template.
+	// Skip it so the wrapped kind's plugin decides the grouping.
+	table[metav1.GroupVersionKind{
+		Group:   apiGroupRunai,
+		Version: "*",
+		Kind:    kindWorkloadRunner,
+	}] = skipTopOwnerGrouper
+
+	return hub
 }

--- a/pkg/podgrouper/podgrouper/hub/hub.go
+++ b/pkg/podgrouper/podgrouper/hub/hub.go
@@ -334,9 +334,10 @@ func NewDefaultPluginsHub(kubeClient client.Client, searchForLegacyPodGroups,
 	}] = skipTopOwnerGrouper
 
 	// Dynamo uses Grove Grouper and needs to propagate metadata from DynamoGraphDeployment to PodGang and PodClique.
+	// Match every served version: v1alpha1 (Dynamo <=1.1.x) and v1beta1 (1.2.0+, which serves/owns the DGD).
 	table[metav1.GroupVersionKind{
 		Group:   "nvidia.com",
-		Version: "v1alpha1",
+		Version: "*",
 		Kind:    "DynamoGraphDeployment",
 	}] = skipTopOwnerGrouper
 

--- a/pkg/podgrouper/podgrouper/hub/hub_test.go
+++ b/pkg/podgrouper/podgrouper/hub/hub_test.go
@@ -9,7 +9,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -80,6 +83,28 @@ var _ = Describe("SupportedTypes", func() {
 			Expect(hasPlugin).To(BeFalse())
 		})
 
+		It("should return skipTopOwner plugin for WorkloadRunner", func() {
+			gvk := metav1.GroupVersionKind{
+				Group:   "run.ai",
+				Version: "v1alpha1",
+				Kind:    "WorkloadRunner",
+			}
+			plugin := hub.GetPodGrouperPlugin(gvk)
+			Expect(plugin).NotTo(BeNil())
+			Expect(plugin.Name()).To(BeEquivalentTo("SkipTopOwner Grouper"))
+		})
+
+		It("should return skipTopOwner plugin for WorkloadRunner of any served version", func() {
+			gvk := metav1.GroupVersionKind{
+				Group:   "run.ai",
+				Version: "v2beta1",
+				Kind:    "WorkloadRunner",
+			}
+			plugin := hub.GetPodGrouperPlugin(gvk)
+			Expect(plugin).NotTo(BeNil())
+			Expect(plugin.Name()).To(BeEquivalentTo("SkipTopOwner Grouper"))
+		})
+
 		It("should return skipTopOwner plugin for TrainJob", func() {
 			gvk := metav1.GroupVersionKind{
 				Group:   "trainer.kubeflow.org",
@@ -89,6 +114,56 @@ var _ = Describe("SupportedTypes", func() {
 			plugin := hub.GetPodGrouperPlugin(gvk)
 			Expect(plugin).NotTo(BeNil())
 			Expect(plugin.Name()).To(BeEquivalentTo("SkipTopOwner Grouper"))
+		})
+	})
+
+	Context("Skip Top Owner Resolution Tests", func() {
+		It("should resolve the owner below a skipped WorkloadRunner through the hub", func() {
+			statefulSet := &appsv1.StatefulSet{
+				TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "StatefulSet"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "wrapped-sts",
+					Namespace: "default",
+					Labels:    map[string]string{queueLabelKey: "wrapped-queue"},
+				},
+			}
+			kubeClient := fake.NewFakeClient(statefulSet)
+			hub := NewDefaultPluginsHub(
+				kubeClient, false, false, queueLabelKey, nodePoolLabelKey, "", "",
+			)
+
+			runner := &unstructured.Unstructured{}
+			runner.SetAPIVersion("run.ai/v1alpha1")
+			runner.SetKind("WorkloadRunner")
+			runner.SetNamespace("default")
+			runner.SetName("runner")
+
+			pod := &v1.Pod{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+			}
+			owners := []*metav1.PartialObjectMetadata{
+				{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "StatefulSet"},
+					ObjectMeta: metav1.ObjectMeta{Name: "wrapped-sts", Namespace: "default"},
+				},
+				{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "run.ai/v1alpha1", Kind: "WorkloadRunner"},
+					ObjectMeta: metav1.ObjectMeta{Name: "runner", Namespace: "default"},
+				},
+			}
+
+			plugin := hub.GetPodGrouperPlugin(metav1.GroupVersionKind{
+				Group: apiGroupRunai, Version: "v1alpha1", Kind: "WorkloadRunner",
+			})
+			Expect(plugin.Name()).To(BeEquivalentTo("SkipTopOwner Grouper"))
+
+			metadata, err := plugin.GetPodGroupMetadata(runner, pod, owners...)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metadata).NotTo(BeNil())
+			Expect(metadata.Queue).To(Equal("wrapped-queue"))
+			Expect(metadata.Owner.Kind).To(Equal("StatefulSet"))
 		})
 	})
 

--- a/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner.go
+++ b/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner.go
@@ -19,18 +19,21 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/grouper"
 )
 
+// GrouperResolver resolves the grouper handling a GVK, or nil when none matches.
+type GrouperResolver func(gvk metav1.GroupVersionKind) grouper.Grouper
+
 type skipTopOwnerGrouper struct {
-	client        client.Client
-	defaultPlugin *defaultgrouper.DefaultGrouper
-	customPlugins map[metav1.GroupVersionKind]grouper.Grouper
+	client         client.Client
+	defaultPlugin  *defaultgrouper.DefaultGrouper
+	resolveGrouper GrouperResolver
 }
 
 func NewSkipTopOwnerGrouper(client client.Client, defaultGrouper *defaultgrouper.DefaultGrouper,
-	customPlugins map[metav1.GroupVersionKind]grouper.Grouper) *skipTopOwnerGrouper {
+	resolveGrouper GrouperResolver) *skipTopOwnerGrouper {
 	return &skipTopOwnerGrouper{
-		client:        client,
-		defaultPlugin: defaultGrouper,
-		customPlugins: customPlugins,
+		client:         client,
+		defaultPlugin:  defaultGrouper,
+		resolveGrouper: resolveGrouper,
 	}
 }
 
@@ -139,8 +142,10 @@ func (sk *skipTopOwnerGrouper) getSupportedTypePGMetadata(
 	lastOwner *unstructured.Unstructured, pod *v1.Pod, otherOwners ...*metav1.PartialObjectMetadata,
 ) (*podgroup.Metadata, error) {
 	ownerKind := metav1.GroupVersionKind(lastOwner.GroupVersionKind())
-	if grouper, found := sk.customPlugins[ownerKind]; found {
-		return grouper.GetPodGroupMetadata(lastOwner, pod, otherOwners...)
+	if sk.resolveGrouper != nil {
+		if resolved := sk.resolveGrouper(ownerKind); resolved != nil {
+			return resolved.GetPodGroupMetadata(lastOwner, pod, otherOwners...)
+		}
 	}
 	return sk.defaultPlugin.GetPodGroupMetadata(lastOwner, pod, otherOwners...)
 }

--- a/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/skiptopowner/skiptopowner_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgroup"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 	grouperplugin "github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/grouper"
@@ -65,7 +66,7 @@ var _ = Describe("SkipTopOwnerGrouper", func() {
 			supportedTypes = map[metav1.GroupVersionKind]grouperplugin.Grouper{
 				{Group: "", Version: "v1", Kind: "Pod"}: defaultGrouper,
 			}
-			plugin = NewSkipTopOwnerGrouper(client, defaultGrouper, supportedTypes)
+			plugin = NewSkipTopOwnerGrouper(client, defaultGrouper, resolverFromMap(supportedTypes))
 		})
 
 		Context("when last owner is a pod", func() {
@@ -430,6 +431,69 @@ var _ = Describe("SkipTopOwnerGrouper", func() {
 			})
 		})
 
+		Context("chained skip-top-owner delegation", func() {
+			var (
+				groveGrouper   *recordingGrouper
+				workloadRunner *unstructured.Unstructured
+				pod            *v1.Pod
+				otherOwners    []*metav1.PartialObjectMetadata
+			)
+
+			BeforeEach(func() {
+				groveGrouper = &recordingGrouper{name: "Grove Grouper"}
+				supportedTypes[metav1.GroupVersionKind{
+					Group: "grove.io", Version: "v1alpha1", Kind: "PodCliqueSet",
+				}] = groveGrouper
+				supportedTypes[metav1.GroupVersionKind{
+					Group: "nvidia.com", Version: "*", Kind: "DynamoGraphDeployment",
+				}] = plugin
+
+				// Dynamo 1.2.0+ serves the DGD as v1beta1, matched via the wildcard version.
+				dgd := newUnstructured("nvidia.com/v1beta1", "DynamoGraphDeployment", "dgd")
+				podCliqueSet := newUnstructured("grove.io/v1alpha1", "PodCliqueSet", "dgd-pcs")
+				podCliqueSet.SetLabels(map[string]string{queueLabelKey: queueName})
+				podClique := newUnstructured("grove.io/v1alpha1", "PodClique", "dgd-pcs-worker")
+				workloadRunner = newUnstructured("run.ai/v1alpha1", "WorkloadRunner", "runner")
+
+				pod = examplePod.DeepCopy()
+				pod.OwnerReferences = []metav1.OwnerReference{
+					{Kind: "PodClique", APIVersion: "grove.io/v1alpha1", Name: podClique.GetName()},
+				}
+
+				Expect(client.Create(context.TODO(), dgd)).To(Succeed())
+				Expect(client.Create(context.TODO(), podCliqueSet)).To(Succeed())
+				Expect(client.Create(context.TODO(), podClique)).To(Succeed())
+				Expect(client.Create(context.TODO(), pod)).To(Succeed())
+				pod.TypeMeta = metav1.TypeMeta{Kind: examplePod.Kind, APIVersion: examplePod.APIVersion}
+
+				otherOwners = []*metav1.PartialObjectMetadata{
+					objectToPartial(podClique),
+					objectToPartial(podCliqueSet),
+					objectToPartial(dgd),
+					objectToPartial(workloadRunner),
+				}
+			})
+
+			It("skips both WorkloadRunner and DGD and lands on the Grove grouper", func() {
+				metadata, err := plugin.GetPodGroupMetadata(workloadRunner, pod, otherOwners...)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metadata).NotTo(BeNil())
+				Expect(metadata.Name).To(Equal("Grove Grouper"))
+				Expect(groveGrouper.calledWith).NotTo(BeNil())
+				Expect(groveGrouper.calledWith.GetKind()).To(Equal("PodCliqueSet"))
+			})
+
+			It("propagates the skipped wrappers' labels down to the Grove owner", func() {
+				workloadRunner.SetLabels(map[string]string{"runner-label": "runner-value"})
+
+				_, err := plugin.GetPodGroupMetadata(workloadRunner, pod, otherOwners...)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(groveGrouper.calledWith.GetLabels()).To(HaveKeyWithValue("runner-label", "runner-value"))
+			})
+		})
+
 		Context("default plugin usage", func() {
 			It("uses default plugin when GVK does not have custom plugin", func() {
 				// Use StatefulSet which is not in supportedTypes
@@ -491,6 +555,42 @@ var _ = Describe("SkipTopOwnerGrouper", func() {
 	})
 
 })
+
+type recordingGrouper struct {
+	name       string
+	calledWith *unstructured.Unstructured
+}
+
+func (r *recordingGrouper) Name() string { return r.name }
+
+func (r *recordingGrouper) GetPodGroupMetadata(
+	topOwner *unstructured.Unstructured, _ *v1.Pod, _ ...*metav1.PartialObjectMetadata,
+) (*podgroup.Metadata, error) {
+	r.calledWith = topOwner
+	return &podgroup.Metadata{Name: r.name}, nil
+}
+
+func newUnstructured(apiVersion, kind, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(apiVersion)
+	obj.SetKind(kind)
+	obj.SetName(name)
+	obj.SetNamespace("default")
+	return obj
+}
+
+func resolverFromMap(table map[metav1.GroupVersionKind]grouperplugin.Grouper) GrouperResolver {
+	return func(gvk metav1.GroupVersionKind) grouperplugin.Grouper {
+		if g, found := table[gvk]; found {
+			return g
+		}
+		gvk.Version = "*"
+		if g, found := table[gvk]; found {
+			return g
+		}
+		return nil
+	}
+}
 
 func objectToPartial(obj client.Object) *metav1.PartialObjectMetadata {
 	objectMeta := metav1.ObjectMeta{


### PR DESCRIPTION
## Description

Manual backport of #2067 to `v0.16`. The automated backport failed to cherry-pick; `v0.17` succeeded as #2070.

**Conflicts resolved** — `v0.16` predates the Karta fallback hub, so the incoming changes had to be adapted:

- `hub.go` struct field is `defaultPlugin`, not `defaultGroupingHandler`.
- Dropped the `kartaFallbackPlugin` assignment and the `run.ai/kartas` RBAC marker; neither exists on this branch.
- `hub_test.go`: dropped the "Generic Karta Fallback Tests" context and the `runtime`/`types`/`ptr` imports it needed. Kept the new "Skip Top Owner Resolution Tests" case and adjusted it to `v0.16`'s 7-argument `NewDefaultPluginsHub` (no `genericKartaFallback`).
- Per §3.2 of the original, the resolver change here stays wildcard-only — there is no Karta hub to delegate to.

## Second commit is required, not optional

`v0.16` registers the DGD at exact `v1alpha1`; `main`/`v0.17` already use `Version: "*"` (widened by #1870, which shipped in v0.17.0 and so is absent here).

This matters because the backport also grants podgrouper read access on `dynamographdeployments`. Today that read 403s, and `handleGetOwnerError` truncates the chain to PodCliqueSet — the Grove grouper runs and grouping is accidentally correct. Once the grant lands, the walk climbs past the DGD to the WorkloadRunner, skips back down, and asks the table for `nvidia.com/v1beta1/DynamoGraphDeployment`. On an unwidened `v0.16` that misses, falls to the default grouper, and produces the flat `minMember: 1` this PR is meant to fix — for anyone on Dynamo ≥1.2.0.

So cherry-pick alone would regress `v1beta1` users. The two commits must land together.

## Related Issues

Backport of #2067. Related to #856.

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None beyond #2067. Note the behavior change is intentional and coupled to the new RBAC: clusters that were previously grouping correctly *because* the DGD read was denied will now walk the full chain. That is the point of the fix, and it is why both commits ship together.

## Additional Notes

Verified on this branch: `go build ./pkg/podgrouper/...` clean, full `./pkg/podgrouper/...` suite passes, `gofmt` clean, and `make manifests` reproduces the cherry-picked `podgrouper.yaml` with no drift (`workloadrunners` and `dynamographdeployments` both present).

The changelog fragment came across with the cherry-pick. I did not add a second one for the widening: `v0.16`'s `make changelog` target is `changie new` with no `KIND`/`BODY` support, so it cannot be driven non-interactively here, and hand-writing fragments is against the contributor guide. Happy to add one if a maintainer runs it interactively.

Consumers to update after this merges: `runai-engine` pins KAI as a submodule (`v3.41` → `v0.16.3`) and hand-maintains its own podgrouper ClusterRole, so the `workloadrunners` and `dynamographdeployments` grants do **not** propagate from the kubebuilder markers here — they need a separate engine-side change, shipped in the same release as the submodule bump.