### PR TITLE
fix(chart): Honor postCleanup.serviceAccountName on the post-delete ServiceAccount

### DIFF
--- a/.changes/unreleased/Fixed-20260816-093535.yaml
+++ b/.changes/unreleased/Fixed-20260816-093535.yaml
@@ -1,5 +1,5 @@
 kind: Fixed
-body: Honor postCleanup.serviceAccountName on the post-delete ServiceAccount, ClusterRole, and ClusterRoleBinding
+body: Honor postCleanup.serviceAccountName for the post-delete ServiceAccount and ClusterRoleBinding subject
 time: 2026-08-16T09:35:35.907047345+01:00
 custom:
     Author: dttung2905

--- a/.changes/unreleased/Fixed-20260816-093535.yaml
+++ b/.changes/unreleased/Fixed-20260816-093535.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: Honor postCleanup.serviceAccountName on the post-delete ServiceAccount, ClusterRole, and ClusterRoleBinding
+time: 2026-08-16T09:35:35.907047345+01:00
+custom:
+    Author: dttung2905
+    Issue: ""

--- a/deployments/kai-scheduler/templates/rbac/post-delete-binding.yaml
+++ b/deployments/kai-scheduler/templates/rbac/post-delete-binding.yaml
@@ -5,15 +5,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: post-delete-cleanup
+  name: {{ .Values.postCleanup.serviceAccountName }}
   annotations:
     {{- include "kai-scheduler.post-delete-hook-annotations" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: post-delete-cleanup
+    name: {{ .Values.postCleanup.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: post-delete-cleanup
+  name: {{ .Values.postCleanup.serviceAccountName }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/deployments/kai-scheduler/templates/rbac/post-delete-binding.yaml
+++ b/deployments/kai-scheduler/templates/rbac/post-delete-binding.yaml
@@ -5,7 +5,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.postCleanup.serviceAccountName }}
+  name: post-delete-cleanup
   annotations:
     {{- include "kai-scheduler.post-delete-hook-annotations" . | nindent 4 }}
 subjects:
@@ -14,6 +14,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.postCleanup.serviceAccountName }}
+  name: post-delete-cleanup
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/deployments/kai-scheduler/templates/rbac/post-delete-clusterrole.yaml
+++ b/deployments/kai-scheduler/templates/rbac/post-delete-clusterrole.yaml
@@ -5,7 +5,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.postCleanup.serviceAccountName }}
+  name: post-delete-cleanup
   annotations:
     {{- include "kai-scheduler.post-delete-hook-annotations" . | nindent 4 }}
 rules:

--- a/deployments/kai-scheduler/templates/rbac/post-delete-clusterrole.yaml
+++ b/deployments/kai-scheduler/templates/rbac/post-delete-clusterrole.yaml
@@ -5,7 +5,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: post-delete-cleanup
+  name: {{ .Values.postCleanup.serviceAccountName }}
   annotations:
     {{- include "kai-scheduler.post-delete-hook-annotations" . | nindent 4 }}
 rules:

--- a/deployments/kai-scheduler/templates/services/post-delete-serviceaccount.yaml
+++ b/deployments/kai-scheduler/templates/services/post-delete-serviceaccount.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: post-delete-cleanup
+  name: {{ .Values.postCleanup.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: kai-operator

--- a/deployments/kai-scheduler/tests/post_delete_test.yaml
+++ b/deployments/kai-scheduler/tests/post_delete_test.yaml
@@ -4,8 +4,13 @@
 suite: test post-delete cleanup hook
 templates:
   - hooks/post/post-delete-job.yaml
+  - services/post-delete-serviceaccount.yaml
+  - rbac/post-delete-clusterrole.yaml
+  - rbac/post-delete-binding.yaml
 tests:
   - it: should delete only operator-managed deployments in the release namespace
+    templates:
+      - hooks/post/post-delete-job.yaml
     release:
       namespace: custom-ns
     asserts:
@@ -17,6 +22,8 @@ tests:
           pattern: delete deployments? --all
 
   - it: should delete kai-config when the config deployer is enabled
+    templates:
+      - hooks/post/post-delete-job.yaml
     set:
       kaiConfigDeployer.enabled: true
     asserts:
@@ -25,6 +32,8 @@ tests:
           pattern: kubectl delete Config kai-config --ignore-not-found
 
   - it: should preserve kai-config when the config deployer is disabled
+    templates:
+      - hooks/post/post-delete-job.yaml
     set:
       kaiConfigDeployer.enabled: false
     asserts:
@@ -33,6 +42,8 @@ tests:
           pattern: kubectl delete Config kai-config
 
   - it: should not delete kai-config in GitOps mode (pruned as a tracked release resource)
+    templates:
+      - hooks/post/post-delete-job.yaml
     set:
       kaiConfigDeployer.enabled: false
       kaiConfig.render: true
@@ -42,6 +53,8 @@ tests:
           pattern: kubectl delete Config kai-config
 
   - it: should carry the ArgoCD PostDelete hook annotations
+    templates:
+      - hooks/post/post-delete-job.yaml
     asserts:
       - equal:
           path: metadata.annotations["argocd.argoproj.io/hook"]
@@ -51,6 +64,8 @@ tests:
           value: BeforeHookCreation,HookSucceeded
 
   - it: should place the cleanup job in the release namespace
+    templates:
+      - hooks/post/post-delete-job.yaml
     release:
       namespace: custom-ns
     asserts:
@@ -64,3 +79,57 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should use the default postCleanup.serviceAccountName on the job
+    templates:
+      - hooks/post/post-delete-job.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: post-delete-cleanup
+
+  - it: should name the ServiceAccount from postCleanup.serviceAccountName
+    templates:
+      - services/post-delete-serviceaccount.yaml
+    set:
+      postCleanup.serviceAccountName: custom-cleanup-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-cleanup-sa
+
+  - it: should name the ClusterRole from postCleanup.serviceAccountName
+    templates:
+      - rbac/post-delete-clusterrole.yaml
+    set:
+      postCleanup.serviceAccountName: custom-cleanup-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-cleanup-sa
+
+  - it: should wire ClusterRoleBinding subject and roleRef from postCleanup.serviceAccountName
+    templates:
+      - rbac/post-delete-binding.yaml
+    set:
+      postCleanup.serviceAccountName: custom-cleanup-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-cleanup-sa
+      - equal:
+          path: subjects[0].name
+          value: custom-cleanup-sa
+      - equal:
+          path: roleRef.name
+          value: custom-cleanup-sa
+
+  - it: should point the Job at the custom ServiceAccount
+    templates:
+      - hooks/post/post-delete-job.yaml
+    set:
+      postCleanup.serviceAccountName: custom-cleanup-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: custom-cleanup-sa

--- a/deployments/kai-scheduler/tests/post_delete_test.yaml
+++ b/deployments/kai-scheduler/tests/post_delete_test.yaml
@@ -98,7 +98,7 @@ tests:
           path: metadata.name
           value: custom-cleanup-sa
 
-  - it: should name the ClusterRole from postCleanup.serviceAccountName
+  - it: should keep ClusterRole name fixed when serviceAccountName changes
     templates:
       - rbac/post-delete-clusterrole.yaml
     set:
@@ -106,9 +106,9 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: custom-cleanup-sa
+          value: post-delete-cleanup
 
-  - it: should wire ClusterRoleBinding subject and roleRef from postCleanup.serviceAccountName
+  - it: should bind the custom ServiceAccount while keeping ClusterRoleBinding and roleRef fixed
     templates:
       - rbac/post-delete-binding.yaml
     set:
@@ -116,13 +116,13 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: custom-cleanup-sa
+          value: post-delete-cleanup
       - equal:
           path: subjects[0].name
           value: custom-cleanup-sa
       - equal:
           path: roleRef.name
-          value: custom-cleanup-sa
+          value: post-delete-cleanup
 
   - it: should point the Job at the custom ServiceAccount
     templates:

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -302,8 +302,7 @@ postCleanup:
     name: crd-upgrader
     pullPolicy: IfNotPresent
     # tag: ""  # Optional: Override global.tag or Chart.AppVersion
-  # Name of the ServiceAccount, ClusterRole, and ClusterRoleBinding used by the
-  # post-delete hook Job. Keep these resources in sync by changing this one value.
+  # Name of the ServiceAccount used by the post-delete hook Job.
   serviceAccountName: post-delete-cleanup
   resources: {}
 

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -302,6 +302,8 @@ postCleanup:
     name: crd-upgrader
     pullPolicy: IfNotPresent
     # tag: ""  # Optional: Override global.tag or Chart.AppVersion
+  # Name of the ServiceAccount, ClusterRole, and ClusterRoleBinding used by the
+  # post-delete hook Job. Keep these resources in sync by changing this one value.
   serviceAccountName: post-delete-cleanup
   resources: {}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

`postCleanup.serviceAccountName` is ignored by SA/RBAC templates although it is mentioned in `values.yaml` file
https://github.com/kai-scheduler/KAI-Scheduler/blob/a000d1a23f2f793780a5a1f62e73e065f1995829/deployments/kai-scheduler/values.yaml#L298-L305


## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
