### PR TITLE
chore(release): prepare changelog for v0.16.9

### DIFF
--- a/.changes/unreleased/added-20260802-003926.yaml
+++ b/.changes/unreleased/added-20260802-003926.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: |-
-  Reservation pods inherit fractional pod tolerations

--- a/.changes/unreleased/fixed-20260728-212512.yaml
+++ b/.changes/unreleased/fixed-20260728-212512.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Allow PodGroup minMember and minSubGroup of 0 for workloads with no gang requirement

--- a/.changes/unreleased/fixed-20260806-221852.yaml
+++ b/.changes/unreleased/fixed-20260806-221852.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Propagate Kubernetes client QPS and burst settings to operator-managed controllers

--- a/.changes/unreleased/fixed-20260812-141030.yaml
+++ b/.changes/unreleased/fixed-20260812-141030.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Podgrouper skips WorkloadRunner wrapper so wrapped workloads keep their gang grouping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [v0.16.9] - 2026-08-16
+
+### Added
+- Reservation pods inherit fractional pod tolerations
+
+### Fixed
+- Allow PodGroup minMember and minSubGroup of 0 for workloads with no gang requirement
+- Propagate Kubernetes client QPS and burst settings to operator-managed controllers
+- Podgrouper skips WorkloadRunner wrapper so wrapped workloads keep their gang grouping
+
 ## [v0.16.8] - 2026-07-29
 
 ### Fixed


### PR DESCRIPTION
Automated by the **Release — Prepare Changelog** workflow.

Folds the pending `.changes/unreleased/` fragments into `CHANGELOG.md` as `## [v0.16.9]` and clears them. `CHANGELOG.md` is the source of truth.

**Merging this PR** triggers `release-publish.yaml`, which tags `v0.16.9` and creates the GitHub Release from this changelog section.

- Review the new `## [v0.16.9]` section for accuracy.
- Target branch: `v0.16`.
