### PR TITLE
fix(api): allow PodGroup minMember of 0 (v0.12 backport)

### DIFF
--- a/.changes/unreleased/fixed-20260728-212512.yaml
+++ b/.changes/unreleased/fixed-20260728-212512.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Allow creating PodGroups with an explicit minMember of 0

--- a/deployments/kai-scheduler/crds/scheduling.run.ai_podgroups.yaml
+++ b/deployments/kai-scheduler/crds/scheduling.run.ai_podgroups.yaml
@@ -64,8 +64,9 @@ spec:
                 description: |-
                   MinMember defines the minimal number of members to run the PodGroup;
                   if there are not enough resources to start all required members, the scheduler will not start anyone.
+                  A value of 0 means no gang requirement: all pods are scheduled elastically (e.g. scale-to-zero workloads).
                 format: int32
-                minimum: 1
+                minimum: 0
                 type: integer
               parallelism:
                 description: The number of pods which will try to run at any instant.

--- a/pkg/apis/scheduling/v2alpha2/podgroup_types.go
+++ b/pkg/apis/scheduling/v2alpha2/podgroup_types.go
@@ -34,7 +34,8 @@ import (
 type PodGroupSpec struct {
 	// MinMember defines the minimal number of members to run the PodGroup;
 	// if there are not enough resources to start all required members, the scheduler will not start anyone.
-	// +kubebuilder:validation:Minimum=1
+	// A value of 0 means no gang requirement: all pods are scheduled elastically (e.g. scale-to-zero workloads).
+	// +kubebuilder:validation:Minimum=0
 	MinMember int32 `json:"minMember,omitempty" protobuf:"bytes,1,opt,name=minMember"`
 
 	// Queue defines the queue to allocate resource for PodGroup; if queue does not exist,

--- a/pkg/podgrouper/podgrouper/plugins/knative/knative_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/knative/knative_test.go
@@ -4,7 +4,6 @@
 package knative
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -113,6 +112,17 @@ func TestGetPodGroupMetadata(t *testing.T) {
 }
 
 func TestGetPodGroupMetadata_MinScale(t *testing.T) {
+	for minScale, expectedMinAvailable := range map[string]int32{
+		"3": 3,
+		"0": 0, // scale-to-zero: no gang requirement
+	} {
+		t.Run("min-scale="+minScale, func(t *testing.T) {
+			testGetPodGroupMetadataMinScale(t, minScale, expectedMinAvailable)
+		})
+	}
+}
+
+func testGetPodGroupMetadataMinScale(t *testing.T, minScale string, expectedMinAvailable int32) {
 	service := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "Service",
@@ -156,7 +166,7 @@ func TestGetPodGroupMetadata_MinScale(t *testing.T) {
 			Namespace: "test_namespace",
 			UID:       "2",
 			Annotations: map[string]string{
-				"autoscaling.knative.dev/min-scale": "3",
+				"autoscaling.knative.dev/min-scale": minScale,
 			},
 		},
 		Spec:   knative.RevisionSpec{},
@@ -197,7 +207,7 @@ func TestGetPodGroupMetadata_MinScale(t *testing.T) {
 	assert.Equal(t, "pg-revision-2", metadata.Name)
 	assert.Equal(t, constants.InferencePriorityClass, metadata.PriorityClassName)
 	assert.Equal(t, "test_queue", metadata.Queue)
-	assert.Equal(t, "3", strconv.Itoa(int(metadata.MinAvailable)))
+	assert.Equal(t, expectedMinAvailable, metadata.MinAvailable)
 }
 
 func TestGetPodGroupMetadataBackwardsCompatibility(t *testing.T) {

--- a/pkg/scheduler/api/podgroup_info/job_info_test.go
+++ b/pkg/scheduler/api/podgroup_info/job_info_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
+	enginev2alpha2 "github.com/NVIDIA/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
 	commonconstants "github.com/NVIDIA/KAI-scheduler/pkg/common/constants"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/NVIDIA/KAI-scheduler/pkg/scheduler/api/pod_info"
@@ -118,6 +119,37 @@ func TestAddTaskInfo(t *testing.T) {
 			t.Errorf("podset info %d: \n expected: %v, \n got: %v \n",
 				i, test.expected, ps)
 		}
+	}
+}
+
+func TestSetPodGroupMinMember(t *testing.T) {
+	tests := []struct {
+		name             string
+		minMember        int32
+		expectedMinAvail int32
+	}{
+		// int32 cannot distinguish unset from explicit 0; both default to a gang of 1
+		{"zero or unset minMember defaults to 1", 0, 1},
+		{"positive minMember is honored", 3, 3},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			info := NewPodGroupInfo("group-1")
+			info.SetPodGroup(&enginev2alpha2.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "group-1",
+					Namespace: "ns-1",
+				},
+				Spec: enginev2alpha2.PodGroupSpec{
+					Queue:     "queue-1",
+					MinMember: test.minMember,
+				},
+			})
+
+			if got := info.PodSets[DefaultSubGroup].GetMinAvailable(); got != test.expectedMinAvail {
+				t.Errorf("expected minAvailable %d, got %d", test.expectedMinAvail, got)
+			}
+		})
 	}
 }
 

--- a/test/e2e/suites/integrations/third_party/knative/knative_test.go
+++ b/test/e2e/suites/integrations/third_party/knative/knative_test.go
@@ -118,6 +118,32 @@ var _ = Describe("Knative integration", Ordered, func() {
 				"Expected minmember of podgroup to be 1")
 		})
 
+		It("knative service with scale-to-zero - minscale 0", func(ctx context.Context) {
+			namespace := queue.GetConnectedNamespaceToQueue(testCtx.Queues[0])
+			serviceName := "knative-service-" + utils.GenerateRandomK8sName(10)
+
+			knativeService := getKnativeServiceObject(serviceName, namespace, testCtx.Queues[0].Name)
+
+			knativeService.Spec.ConfigurationSpec.Template.Annotations[minScaleAnnotation] = "0"
+
+			Expect(testCtx.ControllerClient.Create(ctx, knativeService)).To(Succeed())
+			defer func() {
+				Expect(testCtx.ControllerClient.Delete(ctx, knativeService)).To(Succeed())
+			}()
+
+			// Knative still creates the initial pod on deployment even with min-scale 0
+			pods := getServicePods(ctx, testCtx, serviceName, namespace, 1)
+
+			wait.ForPodsScheduled(ctx, testCtx.ControllerClient, namespace, pods)
+
+			var podGroups v2alpha2.PodGroupList
+			Expect(testCtx.ControllerClient.List(ctx, &podGroups, client.InNamespace(namespace))).To(Succeed())
+			Expect(len(podGroups.Items)).To(Equal(1),
+				"Expected one podgroup for the revision")
+			Expect(podGroups.Items[0].Spec.MinMember).To(Equal(int32(0)),
+				"Expected minmember of podgroup to be 0")
+		})
+
 		Context("Non-Gang scheduling", func() {
 			BeforeAll(func(ctx context.Context) {
 				setKnativeGangAndWait(ctx, testCtx, pointer.Bool(false))


### PR DESCRIPTION
## Description

Backport of #1989 to `v0.12`.

Adapted for this branch: `MinMember` here is a plain `int32` (not `*int32` as on main) and `minSubGroup` does not exist, so:
- CRD/kubebuilder marker relaxed from `Minimum=1` to `Minimum=0`: explicit `minMember: 0` (e.g. knative scale-to-zero podgroups) is no longer rejected by the API server.
- The scheduler's existing default of minAvailable 1 is kept: since a non-pointer `int32` with `omitempty` cannot distinguish unset from explicit 0, honoring 0 would silently flip gang semantics for PodGroups created without `minMember` (this is asserted by `TestSnapshotPodGroups`). The full elastic minMember=0 behavior from main is therefore not backported.
- The `minSubGroup` webhook/e2e changes from the original PR are dropped (field does not exist on this branch).

Same adaptation as #2085 (v0.14).

## Related Issues

Backport of #1989.

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None.

## Additional Notes

Unit tests pass locally for `pkg/scheduler/api/podgroup_info`, `pkg/scheduler/cache/...`, `pkg/podgrouper/.../knative`, and `pkg/apis/scheduling/v2alpha2`. The v0.9 backport (#2087) was closed: that branch never had the `Minimum=1` marker, so the bug does not exist there.