### PR TITLE
chore: disable CodeRabbit review status (backport #2023 to v0.12)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,13 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+
+reviews:
+  review_status: false
+  auto_review:
+    enabled: false
+  finishing_touches:
+    docstrings:
+      enabled: false


### PR DESCRIPTION
## Description

Backport of #2023 to the `v0.12` release branch.

Disables the CodeRabbit review status comment by setting `reviews.review_status: false` in `.coderabbit.yaml`. This branch had no `.coderabbit.yaml`, so the full file from `main` (including the change) is added.

## Related Issues

Backport of #2023

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None

## Additional Notes

CI/tooling-only change.