### PR TITLE
chore: disable CodeRabbit review status (backport #2023 to v0.17)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,6 +5,7 @@
 language: "en-US"
 
 reviews:
+  review_status: false
   auto_review:
     enabled: false
   finishing_touches:


### PR DESCRIPTION
## Description

Backport of #2023 to the `v0.17` release branch.

Disables the CodeRabbit review status comment by setting `reviews.review_status: false` in `.coderabbit.yaml`. Clean cherry-pick of c048f657.

## Related Issues

Backport of #2023

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None

## Additional Notes

CI/tooling-only change.