### PR TITLE
chore(release): prepare changelog for v0.14.8

### DIFF
--- a/.changes/unreleased/0001-fixed.yaml
+++ b/.changes/unreleased/0001-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Fixed extended resources present on only a subset of nodes being reported as unavailable cluster-wide: `ResourceVector.SetMax` now grows the accumulator to the longer vector's length instead of silently dropping resource indices discovered after the first-iterated node, which caused pods requesting such resources to be rejected as unschedulable ("No node in the node-pool has X resources") depending on node map iteration order. [#1851](https://github.com/kai-scheduler/KAI-Scheduler/issues/1851)

--- a/.changes/unreleased/0002-fixed.yaml
+++ b/.changes/unreleased/0002-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Block NaN value for fraction in the pod admission [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0003-fixed.yaml
+++ b/.changes/unreleased/0003-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0004-fixed.yaml
+++ b/.changes/unreleased/0004-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Podgrouper now rejects negative PyTorch replica indexes and LWS worker indexes, and caps the number of subgroups created for block-level segmentation at 10000 to avoid unbounded PodGroup fan-out. [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0005-fixed.yaml
+++ b/.changes/unreleased/0005-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.

--- a/.changes/unreleased/0006-fixed.yaml
+++ b/.changes/unreleased/0006-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Fixed scheduler panic during reclaim when building eviction messages for jobs in root-level queues (`ParentQueue` empty) that reclaim across hierarchy branches. [#1863](https://github.com/kai-scheduler/KAI-Scheduler/issues/1863)

--- a/.changes/unreleased/fixed-20260715-144734.yaml
+++ b/.changes/unreleased/fixed-20260715-144734.yaml
@@ -1,5 +1,0 @@
-kind: Fixed
-body: |-
-  Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.
-custom:
-  Issue: "1728"

--- a/.changes/unreleased/fixed-20260728-212512.yaml
+++ b/.changes/unreleased/fixed-20260728-212512.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Allow creating PodGroups with an explicit minMember of 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [v0.14.8] - 2026-08-19
+
+### Fixed
+- Fixed extended resources present on only a subset of nodes being reported as unavailable cluster-wide: `ResourceVector.SetMax` now grows the accumulator to the longer vector's length instead of silently dropping resource indices discovered after the first-iterated node, which caused pods requesting such resources to be rejected as unschedulable ("No node in the node-pool has X resources") depending on node map iteration order. [#1851](https://github.com/kai-scheduler/KAI-Scheduler/issues/1851)
+- Block NaN value for fraction in the pod admission [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
+- In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
+- Podgrouper now rejects negative PyTorch replica indexes and LWS worker indexes, and caps the number of subgroups created for block-level segmentation at 10000 to avoid unbounded PodGroup fan-out. [davidLif](https://github.com/davidLif)
+- Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.
+- Fixed scheduler panic during reclaim when building eviction messages for jobs in root-level queues (`ParentQueue` empty) that reclaim across hierarchy branches. [#1863](https://github.com/kai-scheduler/KAI-Scheduler/issues/1863)
+- Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection. [#1728](https://github.com/kai-scheduler/KAI-Scheduler/issues/1728)
+- Allow creating PodGroups with an explicit minMember of 0
+
 ## [v0.14.6] - 2026-06-22
 
 ### Added


### PR DESCRIPTION
Automated by the **Release — Prepare Changelog** workflow.

Folds the pending `.changes/unreleased/` fragments into `CHANGELOG.md` as `## [v0.14.8]` and clears them. `CHANGELOG.md` is the source of truth.

**Merging this PR** triggers `release-publish.yaml`, which tags `v0.14.8` and creates the GitHub Release from this changelog section.

- Review the new `## [v0.14.8]` section for accuracy.
- Target branch: `v0.14`.
