### PR TITLE
chore(release): prepare changelog for v0.12.24

### DIFF
--- a/.changes/unreleased/0001-fixed.yaml
+++ b/.changes/unreleased/0001-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Block NaN value for fraction in the pod admission [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0002-fixed.yaml
+++ b/.changes/unreleased/0002-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)

--- a/.changes/unreleased/0003-fixed.yaml
+++ b/.changes/unreleased/0003-fixed.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.

--- a/.changes/unreleased/fixed-20260728-212512.yaml
+++ b/.changes/unreleased/fixed-20260728-212512.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Allow creating PodGroups with an explicit minMember of 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [v0.12.24] - 2026-08-19
+
+### Fixed
+- Block NaN value for fraction in the pod admission [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
+- In the fractional admission checks, check that the fractional value can be parsed as a quantity. [#1798](https://github.com/kai-scheduler/KAI-Scheduler/issues/1798) [davidLif](https://github.com/davidLif)
+- Fixed GPU-sharing pods with dotted pod names generating invalid ConfigMap-backed volume names. Volume names are now sanitized to valid DNS labels while preserving original ConfigMap references used for shared-GPU injection.
+- Allow creating PodGroups with an explicit minMember of 0
+
 ## [v0.12.22] - 2026-06-22
 
 ### Fixed


### PR DESCRIPTION
Automated by the **Release — Prepare Changelog** workflow.

Folds the pending `.changes/unreleased/` fragments into `CHANGELOG.md` as `## [v0.12.24]` and clears them. `CHANGELOG.md` is the source of truth.

**Merging this PR** triggers `release-publish.yaml`, which tags `v0.12.24` and creates the GitHub Release from this changelog section.

- Review the new `## [v0.12.24]` section for accuracy.
- Target branch: `v0.12`.
