### PR TITLE
Fix operator imagePullPolicies ignoring global.imagePullPolicy

### DIFF
--- a/.changes/unreleased/Fixed-20260823-164850.yaml
+++ b/.changes/unreleased/Fixed-20260823-164850.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: fix operator imagePullPolicy ignoring global.imagePullPolicy
+time: 2026-08-23T16:48:50.125518535+01:00
+custom:
+    Author: dttung2905
+    Issue: ""

--- a/deployments/kai-scheduler/templates/hooks/post/kai-config-deployer/job.yaml
+++ b/deployments/kai-scheduler/templates/hooks/post/kai-config-deployer/job.yaml
@@ -49,7 +49,7 @@ spec:
       containers:
       - name: deployer
         image: "{{ .Values.kaiConfigDeployer.image.registry | default .Values.global.registry }}/{{ .Values.kaiConfigDeployer.image.name }}:{{ include "kai-scheduler.imageTag" (dict "root" $ "tag" .Values.kaiConfigDeployer.image.tag) }}"
-        imagePullPolicy: {{ .Values.kaiConfigDeployer.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.kaiConfigDeployer.image.pullPolicy | default .Values.global.imagePullPolicy }}
         {{- with .Values.kaiConfigDeployer.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/deployments/kai-scheduler/templates/hooks/post/post-delete-job.yaml
+++ b/deployments/kai-scheduler/templates/hooks/post/post-delete-job.yaml
@@ -46,7 +46,7 @@ spec:
       containers:
         - name: deleter
           image: "{{ .Values.global.registry }}/{{ .Values.postCleanup.image.name }}:{{ include "kai-scheduler.imageTag" (dict "root" $ "tag" .Values.postCleanup.image.tag) }}"
-          imagePullPolicy: {{ .Values.postCleanup.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.postCleanup.image.pullPolicy | default .Values.global.imagePullPolicy }}
           {{- with .Values.postCleanup.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/deployments/kai-scheduler/templates/hooks/pre/crd-upgrader.yaml
+++ b/deployments/kai-scheduler/templates/hooks/pre/crd-upgrader.yaml
@@ -40,7 +40,7 @@ spec:
       containers:
       - name: upgrader
         image: "{{ .Values.crdupgrader.image.registry | default .Values.global.registry }}/{{ .Values.crdupgrader.image.name }}:{{ include "kai-scheduler.imageTag" (dict "root" $ "tag" .Values.crdupgrader.image.tag) }}"
-        imagePullPolicy: {{ .Values.crdupgrader.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.crdupgrader.image.pullPolicy | default .Values.global.imagePullPolicy }}
         {{- with .Values.crdupgrader.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/deployments/kai-scheduler/templates/hooks/pre/topology-migration/job.yaml
+++ b/deployments/kai-scheduler/templates/hooks/pre/topology-migration/job.yaml
@@ -41,7 +41,7 @@ spec:
       containers:
       - name: migration
         image: "{{ .Values.global.registry }}/{{ .Values.topologyMigration.image.name }}:{{ include "kai-scheduler.imageTag" (dict "root" $ "tag" .Values.topologyMigration.image.tag) }}"
-        imagePullPolicy: {{ .Values.topologyMigration.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.topologyMigration.image.pullPolicy | default .Values.global.imagePullPolicy }}
         {{- with .Values.topologyMigration.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/deployments/kai-scheduler/templates/services/operator.yaml
+++ b/deployments/kai-scheduler/templates/services/operator.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
       - name: operator
         image: {{ .Values.global.registry }}/{{ .Values.operator.image.name }}:{{ include "kai-scheduler.imageTag" (dict "root" $ "tag" .Values.operator.image.tag) }}
-        imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.operator.image.pullPolicy | default .Values.global.imagePullPolicy }}
         {{- with .Values.operator.resources }}
         resources:
           {{- toYaml . | nindent 12 }}

--- a/deployments/kai-scheduler/tests/image_pull_policy_test.yaml
+++ b/deployments/kai-scheduler/tests/image_pull_policy_test.yaml
@@ -1,0 +1,56 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test imagePullPolicy falls back to global.imagePullPolicy
+
+templates:
+  - services/operator.yaml
+  - hooks/post/kai-config-deployer/job.yaml
+  - hooks/post/post-delete-job.yaml
+  - hooks/pre/crd-upgrader.yaml
+  - hooks/pre/topology-migration/job.yaml
+tests:
+  - it: should fall back to global.imagePullPolicy on the operator when unset
+    set:
+      global.imagePullPolicy: Always
+      operator.image.pullPolicy: null
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+        template: services/operator.yaml
+
+  - it: should prefer operator.image.pullPolicy over global.imagePullPolicy
+    set:
+      global.imagePullPolicy: Always
+      operator.image.pullPolicy: Never
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Never
+        template: services/operator.yaml
+
+  - it: should fall back to global.imagePullPolicy on hook images when unset
+    set:
+      global.imagePullPolicy: Always
+      kaiConfigDeployer.image.pullPolicy: null
+      postCleanup.image.pullPolicy: null
+      crdupgrader.image.pullPolicy: null
+      topologyMigration.image.pullPolicy: null
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+        template: hooks/post/kai-config-deployer/job.yaml
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+        template: hooks/post/post-delete-job.yaml
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+        template: hooks/pre/crd-upgrader.yaml
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+        template: hooks/pre/topology-migration/job.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

The operator Deployment and Helm hook Jobs ignored `global.imagePullPolicy`, unlike operand images rendered into the Config CR. This wires the same `| default .Values.global.imagePullPolicy` fallback used elsewhere so an unset per-image `pullPolicy` inherits the global value. Explicit `operator.image.pullPolicy` (and hook equivalents) still take precedence.


## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
