### PR TITLE
fix(scheduler): pass real feature gates to DRA structured allocator

### DIFF
--- a/.changes/unreleased/fixed-20260825-162456.yaml
+++ b/.changes/unreleased/fixed-20260825-162456.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  DRA allocator now honors PartitionableDevices/ConsumableCapacity feature gates instead of hardcoded empty Features

--- a/pkg/scheduler/plugins/dynamicresources/dra_allocator_features_test.go
+++ b/pkg/scheduler/plugins/dynamicresources/dra_allocator_features_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package dynamicresources_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/dynamic-resource-allocation/cel"
+	"k8s.io/dynamic-resource-allocation/structured"
+	"k8s.io/utils/ptr"
+)
+
+// fakeDeviceClassLister is the minimal structured.DeviceClassLister needed to
+// drive the real k8s.io/dynamic-resource-allocation allocator in tests,
+// without pulling in kai-scheduler's full SharedDRAManager/session wiring.
+type fakeDeviceClassLister struct {
+	classes map[string]*resourceapi.DeviceClass
+}
+
+func (f *fakeDeviceClassLister) List() ([]*resourceapi.DeviceClass, error) {
+	var out []*resourceapi.DeviceClass
+	for _, c := range f.classes {
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+func (f *fakeDeviceClassLister) Get(className string) (*resourceapi.DeviceClass, error) {
+	return f.classes[className], nil
+}
+
+// buildPerDeviceNodeSelectionSlice mirrors the ResourceSlice shape published by
+// DRA drivers using a shared-counter/partitionable-device capacity model (e.g.
+// nvidia-dra-driver-gpu with DynamicMIG): node selection is expressed per-device
+// via Spec.PerDeviceNodeSelection + Device.NodeName, rather than at the slice level.
+func buildPerDeviceNodeSelectionSlice(nodeName string) *resourceapi.ResourceSlice {
+	return &resourceapi.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "node0-gpu"},
+		Spec: resourceapi.ResourceSliceSpec{
+			Driver: "gpu.nvidia.com",
+			Pool: resourceapi.ResourcePool{
+				Name:               nodeName,
+				ResourceSliceCount: 1,
+			},
+			PerDeviceNodeSelection: ptr.To(true),
+			Devices: []resourceapi.Device{
+				{
+					Name:     "gpu0",
+					NodeName: ptr.To(nodeName),
+					Capacity: map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+						"gpu": {Value: resource.MustParse("1")},
+					},
+				},
+			},
+		},
+	}
+}
+
+func buildGpuClaim(name, deviceClassName string) *resourceapi.ResourceClaim {
+	return &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec: resourceapi.ResourceClaimSpec{
+			Devices: resourceapi.DeviceClaim{
+				Requests: []resourceapi.DeviceRequest{
+					{
+						Name: "request",
+						Exactly: &resourceapi.ExactDeviceRequest{
+							DeviceClassName: deviceClassName,
+							AllocationMode:  resourceapi.DeviceAllocationModeExactCount,
+							Count:           1,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// runAllocate replicates exactly how draPlugin.allocate() in dynamicresources.go
+// drives the upstream allocator: same AllocatedState, DeviceClassLister, and
+// Allocate() call shape, differing only in the Features passed to NewAllocator.
+func runAllocate(t *testing.T, features structured.Features) []resourceapi.AllocationResult {
+	t.Helper()
+
+	const deviceClassName = "gpu.nvidia.com"
+	classLister := &fakeDeviceClassLister{
+		classes: map[string]*resourceapi.DeviceClass{
+			deviceClassName: {ObjectMeta: metav1.ObjectMeta{Name: deviceClassName}},
+		},
+	}
+
+	slices := []*resourceapi.ResourceSlice{buildPerDeviceNodeSelectionSlice("node0")}
+	claims := []*resourceapi.ResourceClaim{buildGpuClaim("claim-0", deviceClassName)}
+
+	allocatedState := structured.AllocatedState{
+		AllocatedDevices:         sets.New[structured.DeviceID](),
+		AllocatedSharedDeviceIDs: sets.New[structured.SharedDeviceID](),
+		AggregatedCapacity:       structured.NewConsumedCapacityCollection(),
+	}
+
+	allocator, err := structured.NewAllocator(
+		context.Background(), features,
+		allocatedState,
+		classLister,
+		slices,
+		cel.NewCache(10, cel.Features{}),
+	)
+	require.NoError(t, err)
+
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node0"}}
+	results, err := allocator.Allocate(context.Background(), node, claims)
+	require.NoError(t, err)
+	return results
+}
+
+// TestDRAAllocator_PerDeviceNodeSelection_RequiresPartitionableDevicesFeature reproduces
+// https://github.com/kai-scheduler/KAI-Scheduler/issues/2100: kai-scheduler's
+// dynamicresources plugin calls structured.NewAllocator with a hardcoded empty
+// structured.Features{}, so ResourceSlices published with PerDeviceNodeSelection
+// (the shape used by shared-counter/partitionable-device DRA drivers, e.g.
+// nvidia-dra-driver-gpu with DynamicMIG) are silently dropped from pool gathering
+// and allocation fails with no matching devices, even though a matching device exists.
+func TestDRAAllocator_PerDeviceNodeSelection_RequiresPartitionableDevicesFeature(t *testing.T) {
+	t.Run("pre-fix: empty Features{} silently drops the slice, allocation yields no results", func(t *testing.T) {
+		results := runAllocate(t, structured.Features{})
+		assert.Empty(t, results, "bug reproduced: allocator should return 0 results when PartitionableDevices is not enabled")
+	})
+
+	t.Run("fix: PartitionableDevices enabled, allocator finds and allocates the device", func(t *testing.T) {
+		results := runAllocate(t, structured.Features{PartitionableDevices: true})
+		require.Len(t, results, 1, "fix verified: allocator should allocate the device once PartitionableDevices is set")
+	})
+}

--- a/pkg/scheduler/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/plugins/dynamicresources/dynamicresources.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache"
 	"k8s.io/dynamic-resource-allocation/structured"
 	ksf "k8s.io/kube-scheduler/framework"
+	k8splfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 
 	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
@@ -36,11 +37,26 @@ const (
 type draPlugin struct {
 	manager               ksf.SharedDRAManager
 	celCache              *cel.Cache
+	allocatorFeatures     structured.Features
 	queueLabelKey         string
 	deviceClassByResource *extendedresourcecache.ExtendedResourceCache
 }
 
 // +kubebuilder:rbac:groups="resource.k8s.io",resources=deviceclasses;resourceslices;resourceclaims,verbs=get;list;watch
+
+// allocatorFeatures maps the upstream scheduler feature gates to the
+// structured allocator's Features, mirroring
+// k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources.AllocatorFeatures.
+func allocatorFeatures(features k8splfeature.Features) structured.Features {
+	return structured.Features{
+		AdminAccess:            features.EnableDRAAdminAccess,
+		PrioritizedList:        features.EnableDRAPrioritizedList,
+		PartitionableDevices:   features.EnableDRAPartitionableDevices,
+		DeviceTaints:           features.EnableDRADeviceTaints,
+		DeviceBindingAndStatus: features.EnableDRADeviceBindingConditions && features.EnableDRAResourceClaimDeviceStatus,
+		ConsumableCapacity:     features.EnableDRAConsumableCapacity,
+	}
+}
 
 func New(pluginArgs framework.PluginArguments) framework.Plugin {
 	maxCelCacheEntries, err := pluginArgs.GetInt(maxCelCacheEntriesKey, defaultMaxCelCacheEntries)
@@ -51,7 +67,8 @@ func New(pluginArgs framework.PluginArguments) framework.Plugin {
 
 	features := k8s_utils.GetK8sFeatures()
 	return &draPlugin{
-		celCache: cel.NewCache(maxCelCacheEntries, cel.Features{EnableConsumableCapacity: features.EnableDRAConsumableCapacity}),
+		celCache:          cel.NewCache(maxCelCacheEntries, cel.Features{EnableConsumableCapacity: features.EnableDRAConsumableCapacity}),
+		allocatorFeatures: allocatorFeatures(features),
 	}
 }
 
@@ -270,7 +287,7 @@ func (drap *draPlugin) filter(task *pod_info.PodInfo, _ *podgroup_info.PodGroupI
 	}
 
 	allocator, err := structured.NewAllocator(
-		context.Background(), structured.Features{},
+		context.Background(), drap.allocatorFeatures,
 		*allocatedState,
 		drap.manager.DeviceClasses(),
 		slices,
@@ -415,7 +432,7 @@ func (drap *draPlugin) allocate(node *v1.Node, claims []*resourceapi.ResourceCla
 		return nil, fmt.Errorf("failed to list resource slices: %v", err)
 	}
 	allocator, err := structured.NewAllocator(
-		context.Background(), structured.Features{},
+		context.Background(), drap.allocatorFeatures,
 		*allocatedState,
 		drap.manager.DeviceClasses(),
 		slices,


### PR DESCRIPTION
## Description

`structured.NewAllocator` in the `dynamicresources` plugin was always called with a hardcoded empty `structured.Features{}`. This causes the upstream `k8s.io/dynamic-resource-allocation` allocator to select its `stable` implementation, whose `GatherPools` silently drops any `ResourceSlice` published with `PerDeviceNodeSelection` set — the shape used by shared-counter/partitionable-device DRA drivers (e.g. `nvidia-dra-driver-gpu` with `DynamicMIG=true`). The result is scheduling failures like `cannot allocate all DRA claims on node <node>` even with confirmed free GPU capacity, with no other error signal.

kai-scheduler already detects the real upstream scheduler feature gates via `k8s_utils.GetK8sFeatures()`, but only threaded `EnableDRAConsumableCapacity` into the CEL cache — never into the allocator's `Features` argument. This fix adds an `allocatorFeatures()` mapping (mirroring kube-scheduler's own [`AllocatorFeatures`](https://github.com/kubernetes/kubernetes/blob/v1.35.4/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go#L577)) and passes it to both `structured.NewAllocator` call sites.

## Related Issues

Fixes #2100

## Checklist

- [x] Self-reviewed
- [x] Added/updated tests
- [x] Updated documentation (not needed)
- [x] Added a changelog fragment via `make changelog`

## Breaking Changes

None. This only starts honoring feature gates (`PartitionableDevices`, `ConsumableCapacity`, `AdminAccess`, `DeviceTaints`, `PrioritizedList`, `DeviceBindingAndStatus`) that were previously always disabled in the allocator regardless of cluster configuration.

## Additional Notes

Added `pkg/scheduler/plugins/dynamicresources/dra_allocator_features_test.go`, which drives the real upstream allocator the same way `draPlugin` does:
- With the pre-fix `structured.Features{}`, a claim matching a `PerDeviceNodeSelection` slice's device allocates **0 results**, reproducing the bug.
- With `PartitionableDevices: true`, the same claim/slice allocates successfully.