### PR TITLE
fix(chart): add resource-reservation service account to OpenShift SCC

### DIFF
--- a/.changes/unreleased/fixed-20260826-155433.yaml
+++ b/.changes/unreleased/fixed-20260826-155433.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Add resource-reservation service account to OpenShift SecurityContextConstraints

--- a/deployments/kai-scheduler/templates/rbac/scc.yaml
+++ b/deployments/kai-scheduler/templates/rbac/scc.yaml
@@ -43,6 +43,7 @@ users:
 - system:serviceaccount:{{ .Release.Namespace }}:node-scale-adjuster
 - system:serviceaccount:{{ .Release.Namespace }}:kai-scheduler-crd-manager
 - system:serviceaccount:{{ .Release.Namespace }}:kai-topology-migration
+- system:serviceaccount:{{ .Values.global.resourceReservation.namespace }}:{{ .Values.global.resourceReservation.serviceAccount }}
 volumes:
 - awsElasticBlockStore
 - azureDisk
@@ -134,4 +135,7 @@ subjects:
   - kind: ServiceAccount
     name: kai-topology-migration
     namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: {{ .Values.global.resourceReservation.serviceAccount }}
+    namespace: {{ .Values.global.resourceReservation.namespace }}
 {{- end }}


### PR DESCRIPTION
The kai-system SecurityContextConstraints granted use only to service accounts in the release namespace, so reservation pods - which run as the resource-reservation service account in its own namespace - fell back to restricted-v2 and were rejected for runAsUser 10000.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

<!-- What does this PR do and why? -->

## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [ ] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [ ] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
