### PR TITLE
feat(scheduler): Add queuePriorityInQuotaReclaim strategy for reclaim

### DIFF
--- a/.changes/unreleased/added-20260826-192424.yaml
+++ b/.changes/unreleased/added-20260826-192424.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: |-
+  Add queuePriorityInQuotaReclaim strategy for reclaim. If it's enabled (off by default) higher priority queues can reclaim in-quota resources from lower priority queues.

--- a/.changes/unreleased/added-20260826-192424.yaml
+++ b/.changes/unreleased/added-20260826-192424.yaml
@@ -1,3 +1,3 @@
 kind: Added
 body: |-
-  Add queuePriorityInQuotaReclaim strategy for reclaim. If it's enabled (off by default) higher priority queues can reclaim in-quota resources from lower priority queues.
+  Add queuePriorityInQuotaReclaim strategy for reclaim. If it's enabled (off by default) higher priority queues can reclaim in-quota resources from lower priority queues. This is alpha functionality, and the exact behavior of this feature might change in future releases.

--- a/docs/fairness/README.md
+++ b/docs/fairness/README.md
@@ -118,7 +118,8 @@ scheduler:
 | `false` (default) | Only over-quota resources are ever reclaimed — the quota protection guarantee holds for every queue |
 | `true` | A queue can additionally reclaim in-quota resources from any strictly lower priority queue, provided the reclaimer stays within its own deserved quota |
 
-This is alpha functionality; enable it per scheduling shard only when queue `Priority` should outrank quota protection for lower-priority queues.
+This is alpha functionality, and the exact behavior of this feature might change in future releases. 
+Enable `queuePriorityInQuotaReclaim` per scheduling shard only when queue `Priority` should outrank quota protection for lower-priority queues.
 
 ## See Also
 

--- a/docs/fairness/README.md
+++ b/docs/fairness/README.md
@@ -93,10 +93,20 @@ pluginArguments:
 
 ### Priority-Based In-Quota Reclaim
 
-Opt in to letting a strictly higher priority queue reclaim in-quota resources from a strictly lower priority queue, using `queuePriorityInQuotaReclaim`:
+Opt in to letting a strictly higher priority queue reclaim in-quota resources from a strictly lower priority queue, using `queuePriorityInQuotaReclaim`. This is a `proportion` plugin argument, set on the `SchedulingShard` this applies to (see [Scheduler Config Customization](../operator/scheduler-config-customization.md)):
 
 ```yaml
+# SchedulingShard
 spec:
+  plugins:
+    proportion:
+      arguments:
+        queuePriorityInQuotaReclaim: "true"
+```
+
+```yaml
+# Helm values — templated into the default SchedulingShard's spec.plugins
+scheduler:
   plugins:
     proportion:
       arguments:

--- a/docs/fairness/README.md
+++ b/docs/fairness/README.md
@@ -72,6 +72,8 @@ In both strategies, the scheduler ensures that the **relative ordering is preser
 The scheduler will prioritize the first strategy.
 > **Note:** because of the hierarchical nature & priority/weight parametes of job queues in KAI, there are scenarios that a queue will have lower resources allocated than its siblings, yet it'll receive no additional resources via reclaim.
 
+Both strategies only ever reclaim over-quota resources — a queue using only its guaranteed quota is normally never a reclaim victim. Enabling the `queuePriorityInQuotaReclaim` plugin argument (see [Configuration](#configuration)) adds a third, opt-in strategy: a queue can reclaim in-quota resources from another queue with strictly lower `Priority`, as long as the reclaimer itself stays within its own deserved quota. See [Scheduling Deep Dive](../scheduling-deep-dive/README.md#the-quota-protection-guarantee) for details.
+
 ## Configuration
 
 ### Reclaim Sensitivity
@@ -88,6 +90,25 @@ pluginArguments:
 | `1.0` | Standard comparison (default) |
 | `> 1.0` | More conservative reclaim |
 | `< 1.0` | Not allowed (prevents infinite cycles) |
+
+### Priority-Based In-Quota Reclaim
+
+Opt in to letting a strictly higher priority queue reclaim in-quota resources from a strictly lower priority queue, using `queuePriorityInQuotaReclaim`:
+
+```yaml
+spec:
+  plugins:
+    proportion:
+      arguments:
+        queuePriorityInQuotaReclaim: "true"
+```
+
+| Value | Behavior |
+|-------|----------|
+| `false` (default) | Only over-quota resources are ever reclaimed — the quota protection guarantee holds for every queue |
+| `true` | A queue can additionally reclaim in-quota resources from any strictly lower priority queue, provided the reclaimer stays within its own deserved quota |
+
+This is alpha functionality; enable it per scheduling shard only when queue `Priority` should outrank quota protection for lower-priority queues.
 
 ## See Also
 

--- a/docs/queues/README.md
+++ b/docs/queues/README.md
@@ -15,7 +15,7 @@ Only leaf queues (queues with no children) can be used for scheduling jobs. Pare
 | Attribute | Description | Units |
 |-----------|-------------|-------|
 | **Quota** | Guaranteed resource allocation | CPU: millicores, Memory: MB, GPU: units |
-| **Queue Priority** | Resource allocation order when exceeding quota; also gates in-quota reclaim eligibility when the `proportion` plugin's `queuePriorityInQuotaReclaim` argument is enabled — see [Fairness Policies](../fairness/README.md#priority-based-in-quota-reclaim) | Integer (higher = first) |
+| **Queue Priority** | Resource allocation order when exceeding quota; can also affect in-quota reclaim when queuePriorityInQuotaReclaim is enabled, see [Fairness Policies](../fairness/README.md#priority-based-in-quota-reclaim) | Integer (higher = first) |
 | **Over-Quota Weight** | Resource distribution weight within priority level | Integer |
 | **Limit** | Hard cap on resource consumption | Same as quota |
 

--- a/docs/queues/README.md
+++ b/docs/queues/README.md
@@ -15,7 +15,7 @@ Only leaf queues (queues with no children) can be used for scheduling jobs. Pare
 | Attribute | Description | Units |
 |-----------|-------------|-------|
 | **Quota** | Guaranteed resource allocation | CPU: millicores, Memory: MB, GPU: units |
-| **Over-Quota Priority** | Resource allocation order when exceeding quota | Integer (higher = first) |
+| **Queue Priority** | Resource allocation order when exceeding quota; also gates in-quota reclaim eligibility when the `proportion` plugin's `queuePriorityInQuotaReclaim` argument is enabled — see [Fairness Policies](../fairness/README.md#priority-based-in-quota-reclaim) | Integer (higher = first) |
 | **Over-Quota Weight** | Resource distribution weight within priority level | Integer |
 | **Limit** | Hard cap on resource consumption | Same as quota |
 

--- a/docs/scheduling-deep-dive/README.md
+++ b/docs/scheduling-deep-dive/README.md
@@ -106,11 +106,13 @@ For reclaim to occur:
 
 ### The Quota Protection Guarantee
 
-**In-quota resources are protected from reclamation by default.** The scheduler enforces two strategies:
+**In-quota resources are protected from reclamation by default.** The scheduler always enforces two strategies:
 - **MaintainFairShare**: the victim's queue must be above its allocatable fair-share
 - **GuaranteeDeservedQuota**: the reclaimer must be under its deserved quota, AND the victim's queue must be over its deserved quota
 
 This means a queue using only its guaranteed resources will **never** have workloads reclaimed, regardless of what other queues need — as long as this default behavior is in effect.
+
+There is an optional reclaim strategy, which relaxes this guarantee: **queuePriorityInQuotaReclaim**.
 
 #### Opt-in: priority-based in-quota reclaim
 

--- a/docs/scheduling-deep-dive/README.md
+++ b/docs/scheduling-deep-dive/README.md
@@ -88,7 +88,7 @@ Now that both concepts have been introduced, here is how they compare — they a
 | Affects guaranteed quota? | No | No |
 | Affects over-quota distribution? | Yes — order between queues | No |
 | Affects preemption? | No | Yes — determines victims |
-| Affects reclaim? | Indirectly (via fair-share) | No |
+| Affects reclaim? | Indirectly (via fair-share); directly gates in-quota reclaim when `queuePriorityInQuotaReclaim` is enabled | No |
 
 ## Reclaim: Recovering Resources Between Queues
 
@@ -102,21 +102,29 @@ For reclaim to occur:
 1. The reclaimer and victim are in **different queues**
 2. The victim is **preemptible**
 3. The reclaiming queue is **below its fair-share or deserved quota**
-4. The victim's queue is **above its fair-share or deserved quota** (i.e., using over-quota resources)
+4. The victim's queue is **above its fair-share or deserved quota** (i.e., using over-quota resources) — unless the opt-in `queuePriorityInQuotaReclaim` strategy applies (see below)
 
 ### The Quota Protection Guarantee
 
-**In-quota resources are always protected from reclamation.** The scheduler enforces two strategies:
+**In-quota resources are protected from reclamation by default.** The scheduler enforces two strategies:
 - **MaintainFairShare**: the victim's queue must be above its allocatable fair-share
 - **GuaranteeDeservedQuota**: the reclaimer must be under its deserved quota, AND the victim's queue must be over its deserved quota
 
-This means a queue using only its guaranteed resources will **never** have workloads reclaimed, regardless of what other queues need.
+This means a queue using only its guaranteed resources will **never** have workloads reclaimed, regardless of what other queues need — as long as this default behavior is in effect.
+
+#### Opt-in: priority-based in-quota reclaim
+
+The `proportion` plugin argument `queuePriorityInQuotaReclaim` (bool, default `false`) adds a third strategy, **InQuotaQueuePriority**, that weakens this guarantee for a scheduling shard that opts in. When enabled, a reclaimer can evict an in-quota victim's workload if:
+- The reclaimer's queue has **strictly higher `Priority`** than the victim's queue (when queues sit in different hierarchy branches, the comparison uses the ancestor queues where the branches diverge from the lowest common ancestor)
+- The reclaimer **stays within its own deserved quota** after taking the resource — this path never lets a reclaimer go over-quota by reclaiming from an in-quota victim
+
+This is opt-in per scheduling shard (`SchedulingShardSpec.Plugins["proportion"].Arguments`) because it weakens quota protection for lower-priority queues: a non-preemptible workload can no longer be reclaimed, so a queue can still shield itself by filling its quota with non-preemptible workloads.
 
 ### What Reclaim Cannot Do
 
 - **Target workloads in the same queue** — use preemption for intra-queue priority enforcement
 - **Evict non-preemptible workloads** — non-preemptible workloads are filtered out entirely from the reclaim victim pool
-- **Touch in-quota resources** — if a queue is at or below its deserved quota, its workloads are protected
+- **Touch in-quota resources of an equal-or-higher priority queue** — a queue's in-quota workloads are only reclaimable by a strictly higher priority queue, and only when `queuePriorityInQuotaReclaim` is enabled
 
 ## Common Scenarios & FAQ
 
@@ -132,7 +140,7 @@ The answer combines concepts from all three sections above:
 
 3. **If Queue-B is at quota, its resources are protected.** The `GuaranteeDeservedQuota` strategy ensures that a queue at or below its deserved quota cannot be reclaimed from.
 
-**Bottom line:** If Queue-B's training is running within quota, it is protected. Queue-A's inference workload will remain pending until resources become available through other means (Queue-B's workloads completing, cluster scaling up, or Queue-B going over-quota with preemptible workloads).
+**Bottom line:** If Queue-B's training is running within quota, it is protected. Queue-A's inference workload will remain pending until resources become available through other means (Queue-B's workloads completing, cluster scaling up, or Queue-B going over-quota with preemptible workloads) — unless the shard has `queuePriorityInQuotaReclaim` enabled and Queue-A has strictly higher `Priority` than Queue-B, in which case Queue-A can reclaim Queue-B's in-quota preemptible workload directly.
 
 ### "My queue has higher priority — why isn't it getting more resources?"
 

--- a/docs/scheduling-deep-dive/README.md
+++ b/docs/scheduling-deep-dive/README.md
@@ -88,7 +88,7 @@ Now that both concepts have been introduced, here is how they compare — they a
 | Affects guaranteed quota? | No | No |
 | Affects over-quota distribution? | Yes — order between queues | No |
 | Affects preemption? | No | Yes — determines victims |
-| Affects reclaim? | Indirectly (via fair-share); directly gates in-quota reclaim when `queuePriorityInQuotaReclaim` is enabled | No |
+| Affects reclaim? | Yes - effects the fair share calculations and required for the reclaim strategy `queuePriorityInQuotaReclaim` (which is disabled by default) | No |
 
 ## Reclaim: Recovering Resources Between Queues
 

--- a/pkg/scheduler/actions/integration_tests/reclaim/reclaim_test.go
+++ b/pkg/scheduler/actions/integration_tests/reclaim/reclaim_test.go
@@ -12,6 +12,8 @@ import (
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions/integration_tests/integration_tests_utils"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/conf"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/conf_util"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
@@ -4565,5 +4567,171 @@ func getReclaimTestsMetadata() []integration_tests_utils.TestTopologyMetadata {
 				},
 			},
 		},
+		{
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "queuePriorityInQuotaReclaim enabled: higher priority queue reclaims a fully in-quota job from a lower priority queue",
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "low_priority_in_quota_job",
+						RequiredGPUsPerTask: 2,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "low-priority-queue",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								NodeName: "node0",
+								State:    pod_status.Running,
+							},
+						},
+					}, {
+						Name:                "high_priority_pending_job",
+						RequiredGPUsPerTask: 2,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "high-priority-queue",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State: pod_status.Pending,
+							},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {GPUs: 2},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "low-priority-queue",
+						DeservedGPUs:       2,
+						GPUOverQuotaWeight: 1,
+					},
+					{
+						Name:               "high-priority-queue",
+						DeservedGPUs:       2,
+						GPUOverQuotaWeight: 1,
+						Priority:           pointer.Int(commonconstants.DefaultQueuePriority + 1),
+					},
+				},
+				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"low_priority_in_quota_job": {
+						GPUsRequired: 2,
+						Status:       pod_status.Pending,
+					},
+					"high_priority_pending_job": {
+						NodeName:     "node0",
+						GPUsRequired: 2,
+						Status:       pod_status.Running,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds:      1,
+						NumberOfCacheEvictions:  1,
+						NumberOfPipelineActions: 1,
+					},
+					SchedulerConf: schedulerConfigWithQueuePriorityInQuotaReclaim(),
+				},
+			},
+		},
+		{
+			TestTopologyBasic: test_utils.TestTopologyBasic{
+				Name: "queuePriorityInQuotaReclaim enabled: reclaim prefers a same-priority over-quota queue over an in-quota lower priority queue",
+				Jobs: []*jobs_fake.TestJobBasic{
+					{
+						Name:                "high_priority_pending_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "high-priority-queue-a",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								State: pod_status.Pending,
+							},
+						},
+					}, {
+						Name:                "high_priority_over_quota_job",
+						RequiredGPUsPerTask: 2,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "high-priority-queue-b",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								NodeName: "node0",
+								State:    pod_status.Running,
+							},
+						},
+					}, {
+						Name:                "low_priority_in_quota_job",
+						RequiredGPUsPerTask: 1,
+						Priority:            constants.PriorityTrainNumber,
+						QueueName:           "low-priority-queue",
+						Tasks: []*tasks_fake.TestTaskBasic{
+							{
+								NodeName: "node0",
+								State:    pod_status.Running,
+							},
+						},
+					},
+				},
+				Nodes: map[string]nodes_fake.TestNodeBasic{
+					"node0": {GPUs: 3},
+				},
+				Queues: []test_utils.TestQueueBasic{
+					{
+						Name:               "high-priority-queue-a",
+						DeservedGPUs:       1,
+						GPUOverQuotaWeight: 1,
+						Priority:           pointer.Int(commonconstants.DefaultQueuePriority + 1),
+					},
+					{
+						Name:               "high-priority-queue-b",
+						DeservedGPUs:       1,
+						GPUOverQuotaWeight: 1,
+						Priority:           pointer.Int(commonconstants.DefaultQueuePriority + 1),
+					},
+					{
+						Name:               "low-priority-queue",
+						DeservedGPUs:       1,
+						GPUOverQuotaWeight: 1,
+					},
+				},
+				JobExpectedResults: map[string]test_utils.TestExpectedResultBasic{
+					"high_priority_pending_job": {
+						NodeName:     "node0",
+						GPUsRequired: 1,
+						Status:       pod_status.Running,
+					},
+					"high_priority_over_quota_job": {
+						GPUsRequired: 2,
+						Status:       pod_status.Pending,
+					},
+					"low_priority_in_quota_job": {
+						NodeName:     "node0",
+						GPUsRequired: 1,
+						Status:       pod_status.Running,
+					},
+				},
+				Mocks: &test_utils.TestMock{
+					CacheRequirements: &test_utils.CacheMocking{
+						NumberOfCacheBinds:      1,
+						NumberOfCacheEvictions:  1,
+						NumberOfPipelineActions: 1,
+					},
+					SchedulerConf: schedulerConfigWithQueuePriorityInQuotaReclaim(),
+				},
+			},
+		},
 	}
+}
+
+// schedulerConfigWithQueuePriorityInQuotaReclaim returns the default scheduler configuration with
+// the proportion plugin's queuePriorityInQuotaReclaim argument enabled.
+func schedulerConfigWithQueuePriorityInQuotaReclaim() *conf.SchedulerConfiguration {
+	config, err := conf_util.GetDefaultSchedulerConf()
+	if err != nil {
+		panic(err)
+	}
+	config.ScenarioSearchBudgets = nil
+	for i, plugin := range config.Tiers[0].Plugins {
+		if plugin.Name == "proportion" {
+			config.Tiers[0].Plugins[i].Arguments = map[string]string{"queuePriorityInQuotaReclaim": "true"}
+		}
+	}
+	return config
 }

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -62,6 +62,7 @@ type proportionPlugin struct {
 	relcaimerSaturationMultiplier float64
 	kValue                        float64
 	minNodeGPUMemory              *int64
+	queuePriorityInQuotaReclaim   bool
 }
 
 func New(arguments framework.PluginArguments) framework.Plugin {
@@ -83,12 +84,18 @@ func New(arguments framework.PluginArguments) framework.Plugin {
 		kValue = 0.0
 	}
 
+	queuePriorityInQuotaReclaim, err := arguments.GetBool("queuePriorityInQuotaReclaim", false)
+	if err != nil {
+		log.InfraLogger.Warningf("Failed to parse queuePriorityInQuotaReclaim: %v. Using default value of false", err)
+	}
+
 	return &proportionPlugin{
 		totalResource:                 rs.EmptyResourceQuantities(),
 		queues:                        map[common_info.QueueID]*rs.QueueAttributes{},
 		pluginArguments:               arguments,
 		relcaimerSaturationMultiplier: multiplier,
 		kValue:                        kValue,
+		queuePriorityInQuotaReclaim:   queuePriorityInQuotaReclaim,
 	}
 }
 
@@ -101,7 +108,7 @@ func (pp *proportionPlugin) OnSessionOpen(ssn *framework.Session) {
 	pp.subGroupOrderFn = ssn.SubGroupOrderFn
 	pp.taskOrderFunc = ssn.TaskOrderFn
 	pp.minNodeGPUMemory = ssn.ClusterInfo.MinNodeGPUMemoryMiB
-	pp.reclaimablePlugin = rec.New(pp.relcaimerSaturationMultiplier)
+	pp.reclaimablePlugin = rec.New(pp.relcaimerSaturationMultiplier, pp.queuePriorityInQuotaReclaim)
 	capacityPolicy := cp.New(pp.queues, ssn.ClusterInfo.MaxNodeGPUMemoryMiB)
 	ssn.AddQueueOrderFn(pp.queueOrder)
 	ssn.AddCanReclaimResourcesFn(pp.CanReclaimResourcesFn)
@@ -514,7 +521,7 @@ func (pp *proportionPlugin) queueOrder(lQ, rQ *queue_info.QueueInfo, lJob, rJob 
 	}
 
 	return queue_order.GetQueueOrderResult(lQueueAttributes, rQueueAttributes, lJob, rJob, lVictims, rVictims,
-		pp.subGroupOrderFn, pp.taskOrderFunc, pp.totalResource, minNodeGPUMemory)
+		pp.subGroupOrderFn, pp.taskOrderFunc, pp.totalResource, minNodeGPUMemory, pp.queuePriorityInQuotaReclaim)
 }
 
 func (pp *proportionPlugin) getQueueDeservedResourcesFn(queue *queue_info.QueueInfo) *resource_info.ResourceRequirements {

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -1025,5 +1025,24 @@ var _ = Describe("New", func() {
 			Expect(plugin.pluginArguments).To(Equal(args))
 			Expect(plugin.relcaimerSaturationMultiplier).To(Equal(1.0))
 		})
+
+		It("should default queuePriorityInQuotaReclaim to false", func() {
+			plugin := New(args).(*proportionPlugin)
+			Expect(plugin.queuePriorityInQuotaReclaim).To(Equal(false))
+		})
+
+		It("should handle queuePriorityInQuotaReclaim arg", func() {
+			args := framework.PluginArguments{"queuePriorityInQuotaReclaim": "true"}
+			plugin := New(args).(*proportionPlugin)
+			Expect(plugin.pluginArguments).To(Equal(args))
+			Expect(plugin.queuePriorityInQuotaReclaim).To(Equal(true))
+		})
+
+		It("should handle malformed queuePriorityInQuotaReclaim arg", func() {
+			args := framework.PluginArguments{"queuePriorityInQuotaReclaim": "wrong"}
+			plugin := New(args).(*proportionPlugin)
+			Expect(plugin.pluginArguments).To(Equal(args))
+			Expect(plugin.queuePriorityInQuotaReclaim).To(Equal(false))
+		})
 	})
 })

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -1037,12 +1037,5 @@ var _ = Describe("New", func() {
 			Expect(plugin.pluginArguments).To(Equal(args))
 			Expect(plugin.queuePriorityInQuotaReclaim).To(Equal(true))
 		})
-
-		It("should handle malformed queuePriorityInQuotaReclaim arg", func() {
-			args := framework.PluginArguments{"queuePriorityInQuotaReclaim": "wrong"}
-			plugin := New(args).(*proportionPlugin)
-			Expect(plugin.pluginArguments).To(Equal(args))
-			Expect(plugin.queuePriorityInQuotaReclaim).To(Equal(false))
-		})
 	})
 })

--- a/pkg/scheduler/plugins/proportion/queue_order/queue_order.go
+++ b/pkg/scheduler/plugins/proportion/queue_order/queue_order.go
@@ -47,8 +47,22 @@ func GetQueueOrderResult(
 	lVictims, rVictims []*podgroup_info.PodGroupInfo,
 	subGroupOrderFn common_info.LessFn, taskOrderFn common_info.LessFn,
 	totalResources rs.ResourceQuantities, minNodeGPUMemory *int64,
+	queuePriorityInQuotaReclaim bool,
 ) int {
 	var result int
+
+	if queuePriorityInQuotaReclaim {
+		// When the in-quota queue priority reclaim strategy is enabled and both queues would stay
+		// within their deserved quota with the candidate job, priority decides before the starvation
+		// checks below - otherwise a lower priority queue's in-quota job could keep a higher priority
+		// queue's in-quota job waiting.
+		result := prioritizeBasedOnPriorityIfBothQueuesInQuota(
+			lQueue, lJobInfo, rQueue, rJobInfo, subGroupOrderFn, taskOrderFn, minNodeGPUMemory)
+		if result != equalPrioritization {
+			return result
+		}
+	}
+
 	// queues that are currently utilize more than their fair share will be ordered after queues that are under utilize their fair share (based on api.LessFn)
 	result = prioritizeUnderUtilized(lQueue, rQueue)
 	if result != equalPrioritization {
@@ -143,6 +157,31 @@ func prioritizeUnderQuotaWithJob(lQueue, rQueue *rs.QueueAttributes,
 	}
 
 	return equalPrioritization
+}
+
+// prioritizeBasedOnPriorityIfBothQueuesInQuota returns priority ordering only when both queues
+// would remain within their deserved quota after adding their candidate job; otherwise it defers
+// to the caller's existing starvation-based ordering.
+func prioritizeBasedOnPriorityIfBothQueuesInQuota(
+	lQueue *rs.QueueAttributes, lJobInfo *podgroup_info.PodGroupInfo,
+	rQueue *rs.QueueAttributes, rJobInfo *podgroup_info.PodGroupInfo,
+	subGroupOrderFn common_info.LessFn, taskOrderFn common_info.LessFn, minNodeGPUMemory *int64) int {
+	lInQuota := queuesInQuotaWithJob(lQueue, lJobInfo, subGroupOrderFn, taskOrderFn, minNodeGPUMemory)
+	if !lInQuota {
+		return equalPrioritization
+	}
+	rInQuota := queuesInQuotaWithJob(rQueue, rJobInfo, subGroupOrderFn, taskOrderFn, minNodeGPUMemory)
+	if !rInQuota {
+		return equalPrioritization
+	}
+
+	return prioritizePrioritized(lQueue, rQueue)
+}
+
+// queuesInQuotaWithJob returns true when the queue would remain within its deserved quota after adding its candidate job.
+func queuesInQuotaWithJob(queue *rs.QueueAttributes, jobInfo *podgroup_info.PodGroupInfo, subGroupOrderFn common_info.LessFn, taskOrderFn common_info.LessFn, minNodeGPUMemory *int64) bool {
+	resources := jobInitResources(jobInfo, subGroupOrderFn, taskOrderFn, minNodeGPUMemory)
+	return queue.AllocatedPlusResourcesLessEqualDeserved(resources, jobVectorMap(jobInfo))
 }
 
 func jobVectorMap(jobInfo *podgroup_info.PodGroupInfo) *resource_info.ResourceVectorMap {

--- a/pkg/scheduler/plugins/proportion/queue_order/queue_order_test.go
+++ b/pkg/scheduler/plugins/proportion/queue_order/queue_order_test.go
@@ -373,8 +373,153 @@ func TestGetQueueOrderResult(t *testing.T) {
 				return false
 			}
 			result := GetQueueOrderResult(test.lqueue, test.rqueue, test.lJobInfo, test.rJobInfo, nil, nil,
-				session.SubGroupOrderFn, taskOrderFn, test.totalResources, test.minNodeGPUMemory)
+				session.SubGroupOrderFn, taskOrderFn, test.totalResources, test.minNodeGPUMemory, false)
 			assert.Equal(t, test.expectedResult, result)
 		})
 	}
+}
+
+func TestGetQueueOrderResultPriorityInQuotaReclaim(t *testing.T) {
+	tests := []testMetadata{
+		{
+			Name: "both queues in-quota with job: higher priority wins even though it's less starved",
+			lqueue: &resource_share.QueueAttributes{
+				Name:     "lQueue",
+				Priority: 1,
+				QueueResourceShare: resource_share.QueueResourceShare{
+					CPU:    resource_share.ResourceShare{},
+					Memory: resource_share.ResourceShare{},
+					GPU: resource_share.ResourceShare{
+						Deserved:   10,
+						FairShare:  10,
+						MaxAllowed: -1,
+						Allocated:  8,
+					},
+				},
+			},
+			rqueue: &resource_share.QueueAttributes{
+				Name:     "rQueue",
+				Priority: 0,
+				QueueResourceShare: resource_share.QueueResourceShare{
+					CPU:    resource_share.ResourceShare{},
+					Memory: resource_share.ResourceShare{},
+					GPU: resource_share.ResourceShare{
+						Deserved:   10,
+						FairShare:  10,
+						MaxAllowed: -1,
+						Allocated:  0,
+					},
+				},
+			},
+			lJobInfo:       emptyPodGroup("lJob"),
+			rJobInfo:       emptyPodGroup("rJob"),
+			expectedResult: lQueuePrioritized,
+		},
+		{
+			Name: "one queue over-quota with job: priority is not consulted, falls back to starvation order",
+			lqueue: &resource_share.QueueAttributes{
+				Name:     "lQueue",
+				Priority: 1,
+				QueueResourceShare: resource_share.QueueResourceShare{
+					CPU:    resource_share.ResourceShare{},
+					Memory: resource_share.ResourceShare{},
+					GPU: resource_share.ResourceShare{
+						Deserved:   10,
+						FairShare:  10,
+						MaxAllowed: -1,
+						Allocated:  12,
+					},
+				},
+			},
+			rqueue: &resource_share.QueueAttributes{
+				Name:     "rQueue",
+				Priority: 0,
+				QueueResourceShare: resource_share.QueueResourceShare{
+					CPU:    resource_share.ResourceShare{},
+					Memory: resource_share.ResourceShare{},
+					GPU: resource_share.ResourceShare{
+						Deserved:   10,
+						FairShare:  10,
+						MaxAllowed: -1,
+						Allocated:  0,
+					},
+				},
+			},
+			lJobInfo:       emptyPodGroup("lJob"),
+			rJobInfo:       emptyPodGroup("rJob"),
+			expectedResult: rQueuePrioritized,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Logf("Running test %d/%d: %s", i+1, len(tests), test.Name)
+			session := &framework.Session{
+				SubGroupOrderFns: []common_info.CompareFn{
+					subgrouporder.SubGroupOrderFn,
+				},
+			}
+
+			taskOrderFn := func(l, r interface{}) bool {
+				if comparison := taskorder.TaskOrderFn(l, r); comparison != 0 {
+					return comparison < 0
+				}
+				return false
+			}
+			result := GetQueueOrderResult(test.lqueue, test.rqueue, test.lJobInfo, test.rJobInfo, nil, nil,
+				session.SubGroupOrderFn, taskOrderFn, test.totalResources, test.minNodeGPUMemory, true)
+			assert.Equal(t, test.expectedResult, result)
+		})
+	}
+}
+
+func TestGetQueueOrderResultPriorityInQuotaReclaimDisabledKeepsCurrentOrder(t *testing.T) {
+	lqueue := &resource_share.QueueAttributes{
+		Name:     "lQueue",
+		Priority: 1,
+		QueueResourceShare: resource_share.QueueResourceShare{
+			CPU:    resource_share.ResourceShare{},
+			Memory: resource_share.ResourceShare{},
+			GPU: resource_share.ResourceShare{
+				Deserved:   10,
+				FairShare:  10,
+				MaxAllowed: -1,
+				Allocated:  8,
+			},
+		},
+	}
+	rqueue := &resource_share.QueueAttributes{
+		Name:     "rQueue",
+		Priority: 0,
+		QueueResourceShare: resource_share.QueueResourceShare{
+			CPU:    resource_share.ResourceShare{},
+			Memory: resource_share.ResourceShare{},
+			GPU: resource_share.ResourceShare{
+				Deserved:   10,
+				FairShare:  10,
+				MaxAllowed: -1,
+				Allocated:  0,
+			},
+		},
+	}
+	lJob := emptyPodGroup("lJob")
+	rJob := emptyPodGroup("rJob")
+	session := &framework.Session{
+		SubGroupOrderFns: []common_info.CompareFn{
+			subgrouporder.SubGroupOrderFn,
+		},
+	}
+	taskOrderFn := func(l, r interface{}) bool {
+		if comparison := taskorder.TaskOrderFn(l, r); comparison != 0 {
+			return comparison < 0
+		}
+		return false
+	}
+
+	// With the flag disabled, both queues are equally "under-utilized" and "under-quota", so the
+	// existing tie-breakers decide - priority (equalPrioritization is skipped since dominant
+	// resource shares differ) determines the winner the same way it did before this feature existed.
+	result := GetQueueOrderResult(lqueue, rqueue, lJob, rJob, nil, nil,
+		session.SubGroupOrderFn, taskOrderFn, nil, nil, false)
+	assert.Equal(t, lQueuePrioritized, result)
 }

--- a/pkg/scheduler/plugins/proportion/reclaimable/filter_victims.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/filter_victims.go
@@ -29,6 +29,10 @@ func (r *Reclaimable) FilterVictim(
 		return strategies.FitsMaintainFairShare(reclaimeeQueue, reclaimeeQueue.GetAllocatedShare())
 	}
 
+	if r.queuePriorityInQuotaReclaim && reclaimerQueue.Priority > reclaimeeQueue.Priority {
+		return true
+	}
+
 	return canBeDeservedQuotaReclaimCandidate(reclaimer, reclaimeeQueue)
 }
 

--- a/pkg/scheduler/plugins/proportion/reclaimable/filter_victims.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/filter_victims.go
@@ -29,7 +29,7 @@ func (r *Reclaimable) FilterVictim(
 		return strategies.FitsMaintainFairShare(reclaimeeQueue, reclaimeeQueue.GetAllocatedShare())
 	}
 
-	if r.queuePriorityInQuotaReclaim && reclaimerQueue.Priority > reclaimeeQueue.Priority {
+	if strategies.ReclaimerFitsReclaimByQueuePriority(r.queuePriorityInQuotaReclaim, reclaimerQueue, reclaimeeQueue) {
 		return true
 	}
 

--- a/pkg/scheduler/plugins/proportion/reclaimable/reclaimable.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/reclaimable.go
@@ -19,12 +19,14 @@ import (
 )
 
 type Reclaimable struct {
-	saturationMultiplier float64
+	saturationMultiplier        float64
+	queuePriorityInQuotaReclaim bool
 }
 
-func New(multiplier float64) *Reclaimable {
+func New(multiplier float64, queuePriorityInQuotaReclaim bool) *Reclaimable {
 	return &Reclaimable{
-		saturationMultiplier: multiplier,
+		saturationMultiplier:        multiplier,
+		queuePriorityInQuotaReclaim: queuePriorityInQuotaReclaim,
 	}
 }
 
@@ -88,7 +90,7 @@ func (r *Reclaimable) reclaimResourcesFromReclaimees(
 
 		for _, reclaimeeResources := range reclaimeeQueueReclaimedResources {
 			if !strategies.FitsReclaimStrategy(reclaimer.RequiredResources, reclaimer.VectorMap, reclaimerQueue, reclaimeeQueue,
-				remainingResources) {
+				remainingResources, r.queuePriorityInQuotaReclaim) {
 				log.InfraLogger.V(7).Infof("queue <%s>，shouldn't be reclaimed, for %s resources"+
 					" remaining reosurces: <%s>, deserved: <%s>, fairShare: <%s>",
 					reclaimeeQueue.Name, stringVectorArray(reclaimeeQueueReclaimedResources, reclaimer.VectorMap),

--- a/pkg/scheduler/plugins/proportion/reclaimable/reclaimable_test.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/reclaimable_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Can Reclaim Resources", func() {
 		for _, data := range tests {
 			testData := data
 			It(testData.name, func() {
-				reclaimable := New(1.0)
+				reclaimable := New(1.0, false)
 				queues := map[common_info.QueueID]*rs.QueueAttributes{
 					testData.queue.UID: testData.queue,
 				}
@@ -557,7 +557,7 @@ var _ = Describe("Can Reclaim Resources", func() {
 		for _, data := range tests {
 			testData := data
 			It(testData.name, func() {
-				reclaimable := New(1.0)
+				reclaimable := New(1.0, false)
 				queues := map[common_info.QueueID]*rs.QueueAttributes{
 					testData.queue.UID: testData.queue,
 				}
@@ -639,7 +639,7 @@ var _ = Describe("Reclaimable - Single department", func() {
 				},
 			},
 		}
-		reclaimable = New(1.0)
+		reclaimable = New(1.0, false)
 	})
 	It("Reclaimer is below fair share, reclaimee above fair share", func() {
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
@@ -792,7 +792,7 @@ var _ = Describe("Reclaimable - Multiple departments", func() {
 				},
 			},
 		}
-		reclaimable = New(1.0)
+		reclaimable = New(1.0, false)
 	})
 	It("Reclaimer is below fair share, reclaimee above fair share - sanity", func() {
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
@@ -876,7 +876,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New(1.0)
+		reclaimable = New(1.0, false)
 		reclaimees := []*podgroup_info.PodGroupInfo{reclaimee}
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
 		Expect(result).To(Equal(true))
@@ -928,7 +928,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New(1.0)
+		reclaimable = New(1.0, false)
 		reclaimees := []*podgroup_info.PodGroupInfo{reclaimee}
 		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
 		Expect(result).To(Equal(false))
@@ -973,7 +973,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New(1.0)
+		reclaimable = New(1.0, false)
 
 		pod := reclaimee.GetAllPodsMap()["1"]
 		pod.GpuRequirement = *resource_info.NewGpuResourceRequirementWithGpus(1.5, 0)
@@ -1025,7 +1025,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New(1.0)
+		reclaimable = New(1.0, false)
 
 		reclaimerInfo.RequiredResources = resource_info.NewResource(0, 0, 1).ToVector(testVectorMap)
 		reclaimerInfo.Queue = "left-leaf1"
@@ -1074,7 +1074,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 			},
 		}
 		queues := buildQueues(queuesData)
-		reclaimable = New(1.0)
+		reclaimable = New(1.0, false)
 
 		reclaimerInfo.RequiredResources = resource_info.NewResource(0, 0, 1).ToVector(testVectorMap)
 		reclaimerInfo.Queue = "d1-project-1"
@@ -1120,7 +1120,7 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 		queues["d2"].CPU.Allocated = 1000
 		queues["d2"].CPU.FairShare = 1000 // This creates a 1.0 utilization ratio
 
-		reclaimable = New(1.0)
+		reclaimable = New(1.0, false)
 
 		reclaimerInfo.RequiredResources = resource_info.NewResource(0, 0, 1).ToVector(testVectorMap) // Only requests GPU
 		reclaimerInfo.Queue = "d1-project-1"
@@ -1134,6 +1134,83 @@ var _ = Describe("Reclaimable - Multiple hierarchy levels", func() {
 	})
 })
 
+var _ = Describe("Reclaimable - In-quota queue priority strategy", func() {
+	var (
+		reclaimerInfo *ReclaimerInfo
+		reclaimees    []*podgroup_info.PodGroupInfo
+		queues        map[common_info.QueueID]*rs.QueueAttributes
+	)
+	BeforeEach(func() {
+		reclaimerInfo = &ReclaimerInfo{
+			Name:              "reclaimer",
+			Namespace:         "n1",
+			Queue:             "high-priority",
+			IsPreemptable:     true,
+			RequiredResources: resource_info.NewResource(0, 0, 1).ToVector(testVectorMap),
+			VectorMap:         testVectorMap,
+		}
+
+		reclaimee := testReclaimee("reclaimee", "low-priority", pod_info.PodsMap{
+			"1": testPodInfo("1", 3, pod_status.Running),
+		})
+		reclaimees = []*podgroup_info.PodGroupInfo{reclaimee}
+
+		// Both queues are within their deserved quota, so neither MaintainFairShareStrategy nor
+		// GuaranteeDeservedQuotaStrategy would allow this reclaim.
+		queues = map[common_info.QueueID]*rs.QueueAttributes{
+			"high-priority": {
+				UID:      "high-priority",
+				Name:     "high-priority",
+				Priority: 1,
+				QueueResourceShare: rs.QueueResourceShare{
+					GPU: rs.ResourceShare{
+						Deserved:   5,
+						FairShare:  5,
+						Allocated:  0,
+						MaxAllowed: commonconstants.UnlimitedResourceQuantity,
+					},
+					CPU:    rs.ResourceShare{},
+					Memory: rs.ResourceShare{},
+				},
+			},
+			"low-priority": {
+				UID:      "low-priority",
+				Name:     "low-priority",
+				Priority: 0,
+				QueueResourceShare: rs.QueueResourceShare{
+					GPU: rs.ResourceShare{
+						Deserved:   5,
+						FairShare:  5,
+						Allocated:  3,
+						MaxAllowed: commonconstants.UnlimitedResourceQuantity,
+					},
+					CPU:    rs.ResourceShare{},
+					Memory: rs.ResourceShare{},
+				},
+			},
+		}
+	})
+
+	It("does not reclaim an in-quota victim when the flag is disabled", func() {
+		reclaimable := New(1.0, false)
+		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
+		Expect(result).To(Equal(false))
+	})
+
+	It("reclaims an in-quota victim from a strictly lower priority queue when the flag is enabled", func() {
+		reclaimable := New(1.0, true)
+		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
+		Expect(result).To(Equal(true))
+	})
+
+	It("does not reclaim when queues have equal priority even if the flag is enabled", func() {
+		queues["low-priority"].Priority = 1
+		reclaimable := New(1.0, true)
+		result := reclaimable.Reclaimable(queues, reclaimerInfo, reclaimeeResourcesByQueue(reclaimees))
+		Expect(result).To(Equal(false))
+	})
+})
+
 var _ = Describe("FilterVictim", func() {
 	reclaimerInfo := &ReclaimerInfo{
 		Queue:             "reclaimer",
@@ -1143,7 +1220,7 @@ var _ = Describe("FilterVictim", func() {
 	}
 
 	It("filters victims whose leveled queue is strictly under deserved quota", func() {
-		reclaimable := New(1)
+		reclaimable := New(1, false)
 		queues := buildQueues(map[common_info.QueueID]queuesTestData{
 			"reclaimer": {deserved: 4, fairShare: 4, allocated: 0},
 			"victim":    {deserved: 4, fairShare: 4, allocated: 2},
@@ -1153,7 +1230,7 @@ var _ = Describe("FilterVictim", func() {
 	})
 
 	It("keeps victims whose leveled queue is over deserved quota", func() {
-		reclaimable := New(1)
+		reclaimable := New(1, false)
 		queues := buildQueues(map[common_info.QueueID]queuesTestData{
 			"reclaimer": {deserved: 4, fairShare: 4, allocated: 0},
 			"victim":    {deserved: 0, fairShare: 4, allocated: 4},
@@ -1163,7 +1240,7 @@ var _ = Describe("FilterVictim", func() {
 	})
 
 	It("keeps victims exactly at deserved quota for consolidation", func() {
-		reclaimable := New(1)
+		reclaimable := New(1, false)
 		queues := buildQueues(map[common_info.QueueID]queuesTestData{
 			"reclaimer": {deserved: 4, fairShare: 4, allocated: 0},
 			"victim":    {deserved: 2, fairShare: 4, allocated: 2},
@@ -1173,7 +1250,7 @@ var _ = Describe("FilterVictim", func() {
 	})
 
 	It("filters victims under allocatable share when the reclaimer cannot use deserved quota", func() {
-		reclaimable := New(1)
+		reclaimable := New(1, false)
 		queues := buildQueues(map[common_info.QueueID]queuesTestData{
 			"reclaimer": {deserved: 1, fairShare: 4, allocated: 0},
 			"victim":    {deserved: 2, fairShare: 4, allocated: 3},
@@ -1183,13 +1260,73 @@ var _ = Describe("FilterVictim", func() {
 	})
 
 	It("keeps victims over allocatable share when the reclaimer cannot use deserved quota", func() {
-		reclaimable := New(1)
+		reclaimable := New(1, false)
 		queues := buildQueues(map[common_info.QueueID]queuesTestData{
 			"reclaimer": {deserved: 1, fairShare: 4, allocated: 0},
 			"victim":    {deserved: 2, fairShare: 4, allocated: 5},
 		})
 
 		Expect(reclaimable.FilterVictim(queues, reclaimerInfo, "victim")).To(BeTrue())
+	})
+
+	It("filters an in-quota victim from a strictly lower priority queue when the flag is disabled", func() {
+		reclaimable := New(1, false)
+		queues := map[common_info.QueueID]*rs.QueueAttributes{
+			"reclaimer": {
+				UID: "reclaimer", Priority: 1,
+				QueueResourceShare: rs.QueueResourceShare{
+					GPU: rs.ResourceShare{Deserved: 4, FairShare: 4, Allocated: 0, MaxAllowed: commonconstants.UnlimitedResourceQuantity},
+				},
+			},
+			"victim": {
+				UID: "victim", Priority: 0,
+				QueueResourceShare: rs.QueueResourceShare{
+					GPU: rs.ResourceShare{Deserved: 4, FairShare: 4, Allocated: 2, MaxAllowed: commonconstants.UnlimitedResourceQuantity},
+				},
+			},
+		}
+
+		Expect(reclaimable.FilterVictim(queues, reclaimerInfo, "victim")).To(BeFalse())
+	})
+
+	It("keeps an in-quota victim from a strictly lower priority queue when the flag is enabled", func() {
+		reclaimable := New(1, true)
+		queues := map[common_info.QueueID]*rs.QueueAttributes{
+			"reclaimer": {
+				UID: "reclaimer", Priority: 1,
+				QueueResourceShare: rs.QueueResourceShare{
+					GPU: rs.ResourceShare{Deserved: 4, FairShare: 4, Allocated: 0, MaxAllowed: commonconstants.UnlimitedResourceQuantity},
+				},
+			},
+			"victim": {
+				UID: "victim", Priority: 0,
+				QueueResourceShare: rs.QueueResourceShare{
+					GPU: rs.ResourceShare{Deserved: 4, FairShare: 4, Allocated: 2, MaxAllowed: commonconstants.UnlimitedResourceQuantity},
+				},
+			},
+		}
+
+		Expect(reclaimable.FilterVictim(queues, reclaimerInfo, "victim")).To(BeTrue())
+	})
+
+	It("still filters an in-quota victim with equal priority even when the flag is enabled", func() {
+		reclaimable := New(1, true)
+		queues := map[common_info.QueueID]*rs.QueueAttributes{
+			"reclaimer": {
+				UID: "reclaimer", Priority: 1,
+				QueueResourceShare: rs.QueueResourceShare{
+					GPU: rs.ResourceShare{Deserved: 4, FairShare: 4, Allocated: 0, MaxAllowed: commonconstants.UnlimitedResourceQuantity},
+				},
+			},
+			"victim": {
+				UID: "victim", Priority: 1,
+				QueueResourceShare: rs.QueueResourceShare{
+					GPU: rs.ResourceShare{Deserved: 4, FairShare: 4, Allocated: 2, MaxAllowed: commonconstants.UnlimitedResourceQuantity},
+				},
+			},
+		}
+
+		Expect(reclaimable.FilterVictim(queues, reclaimerInfo, "victim")).To(BeFalse())
 	})
 })
 

--- a/pkg/scheduler/plugins/proportion/reclaimable/strategies/strategies.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/strategies/strategies.go
@@ -141,3 +141,11 @@ func ReclaimeeExceedsDeservedQuota(
 ) bool {
 	return !reclaimeeRemainingShare.LessEqual(reclaimeeQueue.GetDeservedShare())
 }
+
+func ReclaimerFitsReclaimByQueuePriority(
+	queuePriorityInQuotaReclaimEnabled bool,
+	reclaimerQueue *rs.QueueAttributes,
+	reclaimeeQueue *rs.QueueAttributes,
+) bool {
+	return queuePriorityInQuotaReclaimEnabled && reclaimerQueue.Priority > reclaimeeQueue.Priority
+}

--- a/pkg/scheduler/plugins/proportion/reclaimable/strategies/strategies.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/strategies/strategies.go
@@ -11,8 +11,10 @@ import (
 
 type MaintainFairShareStrategy struct{}
 type GuaranteeDeservedQuotaStrategy struct{}
+type InQuotaQueuePriorityStrategy struct{}
 
 var strategies = []ReclaimStrategy{&MaintainFairShareStrategy{}, &GuaranteeDeservedQuotaStrategy{}}
+var priorityLeadStrategies = append(append([]ReclaimStrategy{}, strategies...), &InQuotaQueuePriorityStrategy{})
 
 func FitsReclaimStrategy(
 	reclaimerResources resource_info.ResourceVector,
@@ -20,8 +22,14 @@ func FitsReclaimStrategy(
 	reclaimerQueue *rs.QueueAttributes,
 	reclaimeeQueue *rs.QueueAttributes,
 	reclaimeeRemainingShare rs.ResourceQuantities,
+	queuePriorityInQuotaReclaim bool,
 ) bool {
-	for _, strategy := range strategies {
+	applicableStrategies := strategies
+	if queuePriorityInQuotaReclaim {
+		applicableStrategies = priorityLeadStrategies
+	}
+
+	for _, strategy := range applicableStrategies {
 		if strategy.Reclaimable(
 			reclaimerResources, vectorMap, reclaimerQueue, reclaimeeQueue,
 			reclaimeeRemainingShare,
@@ -88,6 +96,28 @@ func (gdqs *GuaranteeDeservedQuotaStrategy) Reclaimable(
 	}
 
 	return true
+}
+
+func (iqps *InQuotaQueuePriorityStrategy) Reclaimable(
+	reclaimerResources resource_info.ResourceVector,
+	vectorMap *resource_info.ResourceVectorMap,
+	reclaimerQueue *rs.QueueAttributes,
+	reclaimeeQueue *rs.QueueAttributes,
+	_ rs.ResourceQuantities) bool {
+	// This strategy allows a strictly higher priority reclaimer to reclaim from an in-quota
+	// reclaimee, as long as the reclaimer stays within its own deserved quota.
+
+	log.InfraLogger.V(6).Do(func() {
+		log.InfraLogger.V(6).Infof("Checking if reclaim is possible for reclaimer <%s> (priority %d) and "+
+			"reclaimee <%s> (priority %d) based on queue priority",
+			reclaimerQueue.Name, reclaimerQueue.Priority, reclaimeeQueue.Name, reclaimeeQueue.Priority)
+	})
+
+	if reclaimerQueue.Priority <= reclaimeeQueue.Priority {
+		return false
+	}
+
+	return ReclaimerFitsDeservedQuota(reclaimerResources, vectorMap, reclaimerQueue)
 }
 
 // FitsMaintainFairShare returns true when the reclaimee remains over its allocatable share.

--- a/pkg/scheduler/plugins/proportion/reclaimable/strategies/strategies_test.go
+++ b/pkg/scheduler/plugins/proportion/reclaimable/strategies/strategies_test.go
@@ -965,4 +965,115 @@ var _ = Describe("Reclaim strategies", func() {
 			})
 		}
 	})
+
+	Context("In Quota Queue Priority Strategy", func() {
+		tests := map[string]struct {
+			reclaimerResources resource_info.ResourceVector
+			reclaimerQueue     *rs.QueueAttributes
+			reclaimeeQueue     *rs.QueueAttributes
+			expected           bool
+		}{
+			"Reclaimer has higher priority and fits its own deserved quota": {
+				reclaimerResources: resource_info.NewResource(0, 0, 1).ToVector(testVectorMap),
+				reclaimerQueue: &rs.QueueAttributes{
+					Name:     "p1",
+					Priority: 1,
+					QueueResourceShare: rs.QueueResourceShare{
+						GPU: rs.ResourceShare{Deserved: 5, Allocated: 2},
+					},
+				},
+				reclaimeeQueue: &rs.QueueAttributes{
+					Name:     "p2",
+					Priority: 0,
+					QueueResourceShare: rs.QueueResourceShare{
+						GPU: rs.ResourceShare{Deserved: 5, Allocated: 1},
+					},
+				},
+				expected: true,
+			},
+			"Reclaimer and reclaimee have equal priority": {
+				reclaimerResources: resource_info.NewResource(0, 0, 1).ToVector(testVectorMap),
+				reclaimerQueue: &rs.QueueAttributes{
+					Name:     "p1",
+					Priority: 0,
+					QueueResourceShare: rs.QueueResourceShare{
+						GPU: rs.ResourceShare{Deserved: 5, Allocated: 2},
+					},
+				},
+				reclaimeeQueue: &rs.QueueAttributes{
+					Name:     "p2",
+					Priority: 0,
+					QueueResourceShare: rs.QueueResourceShare{
+						GPU: rs.ResourceShare{Deserved: 5, Allocated: 1},
+					},
+				},
+				expected: false,
+			},
+			"Reclaimer has lower priority than reclaimee": {
+				reclaimerResources: resource_info.NewResource(0, 0, 1).ToVector(testVectorMap),
+				reclaimerQueue: &rs.QueueAttributes{
+					Name:     "p1",
+					Priority: 0,
+					QueueResourceShare: rs.QueueResourceShare{
+						GPU: rs.ResourceShare{Deserved: 5, Allocated: 2},
+					},
+				},
+				reclaimeeQueue: &rs.QueueAttributes{
+					Name:     "p2",
+					Priority: 1,
+					QueueResourceShare: rs.QueueResourceShare{
+						GPU: rs.ResourceShare{Deserved: 5, Allocated: 1},
+					},
+				},
+				expected: false,
+			},
+			"Reclaimer has higher priority but would go over its own deserved quota": {
+				reclaimerResources: resource_info.NewResource(0, 0, 1).ToVector(testVectorMap),
+				reclaimerQueue: &rs.QueueAttributes{
+					Name:     "p1",
+					Priority: 1,
+					QueueResourceShare: rs.QueueResourceShare{
+						GPU: rs.ResourceShare{Deserved: 2, Allocated: 2},
+					},
+				},
+				reclaimeeQueue: &rs.QueueAttributes{
+					Name:     "p2",
+					Priority: 0,
+					QueueResourceShare: rs.QueueResourceShare{
+						GPU: rs.ResourceShare{Deserved: 5, Allocated: 1},
+					},
+				},
+				expected: false,
+			},
+			"Reclaimer has higher priority and reaches exactly its own deserved quota": {
+				reclaimerResources: resource_info.NewResource(0, 0, 1).ToVector(testVectorMap),
+				reclaimerQueue: &rs.QueueAttributes{
+					Name:     "p1",
+					Priority: 1,
+					QueueResourceShare: rs.QueueResourceShare{
+						GPU: rs.ResourceShare{Deserved: 3, Allocated: 2},
+					},
+				},
+				reclaimeeQueue: &rs.QueueAttributes{
+					Name:     "p2",
+					Priority: 0,
+					QueueResourceShare: rs.QueueResourceShare{
+						GPU: rs.ResourceShare{Deserved: 5, Allocated: 1},
+					},
+				},
+				expected: true,
+			},
+		}
+
+		strategy := &InQuotaQueuePriorityStrategy{}
+		for testName, testData := range tests {
+			testName := testName
+			testData := testData
+			It(testName, func() {
+				reclaimable := strategy.Reclaimable(testData.reclaimerResources, testVectorMap, testData.reclaimerQueue,
+					testData.reclaimeeQueue, testData.reclaimeeQueue.GetAllocatedShare())
+				Expect(reclaimable).To(Equal(testData.expected))
+			})
+		}
+	})
 })


### PR DESCRIPTION
## Description

Add queuePriorityInQuotaReclaim strategy for reclaim. If it's enabled (off by default) higher priority queues can reclaim in-quota resources from lower priority queues.

## Related Issues

Fixes #2065

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
