### PR TITLE
chore(release): prepare changelog for v0.17.1

### DIFF
--- a/.changes/unreleased/Changed-20260803-120000.yaml
+++ b/.changes/unreleased/Changed-20260803-120000.yaml
@@ -1,5 +1,0 @@
-kind: Changed
-body: Renamed Helm value global.fips to global.fipsMode with on/off options
-custom:
-  Issue: "1906"
-  Author: ""

--- a/.changes/unreleased/Fixed-20260717-233428.yaml
+++ b/.changes/unreleased/Fixed-20260717-233428.yaml
@@ -1,6 +1,0 @@
-kind: Fixed
-body: Count a GPU shared by multiple pods through one DRA ResourceClaim once per node, preventing negative idle GPUs.
-time: 2026-07-17T23:34:28.999387137Z
-custom:
-    Author: TensorRaya
-    Issue: "1930"

--- a/.changes/unreleased/Fixed-20260728-181225.yaml
+++ b/.changes/unreleased/Fixed-20260728-181225.yaml
@@ -1,6 +1,0 @@
-kind: Fixed
-body: stalegangeviction no longer evicts remaining pods of a gang whose pods complete successfully
-time: 2026-07-28T18:12:25.0211683+05:30
-custom:
-    Author: Thezone-1
-    Issue: "1968"

--- a/.changes/unreleased/fixed-20260728-212512.yaml
+++ b/.changes/unreleased/fixed-20260728-212512.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Allow PodGroup minMember and minSubGroup of 0 for workloads with no gang requirement

--- a/.changes/unreleased/fixed-20260806-221852.yaml
+++ b/.changes/unreleased/fixed-20260806-221852.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: |-
-  Propagate Kubernetes client QPS and burst settings to operator-managed controllers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [v0.17.1] - 2026-09-02
+
+### Changed
+- Renamed Helm value global.fips to global.fipsMode with on/off options [#1906](https://github.com/kai-scheduler/KAI-Scheduler/issues/1906)
+
+### Fixed
+- Allow PodGroup minMember and minSubGroup of 0 for workloads with no gang requirement
+- Propagate Kubernetes client QPS and burst settings to operator-managed controllers
+- Count a GPU shared by multiple pods through one DRA ResourceClaim once per node, preventing negative idle GPUs. [#1930](https://github.com/kai-scheduler/KAI-Scheduler/issues/1930) [TensorRaya](https://github.com/TensorRaya)
+- stalegangeviction no longer evicts remaining pods of a gang whose pods complete successfully [#1968](https://github.com/kai-scheduler/KAI-Scheduler/issues/1968) [Thezone-1](https://github.com/Thezone-1)
+
 ## [v0.17.0] - 2026-08-03
 
 ### Added


### PR DESCRIPTION
Automated by the **Release — Prepare Changelog** workflow.

Folds the pending `.changes/unreleased/` fragments into `CHANGELOG.md` as `## [v0.17.1]` and clears them. `CHANGELOG.md` is the source of truth.

**Merging this PR** triggers `release-publish.yaml`, which tags `v0.17.1` and creates the GitHub Release from this changelog section.

- Review the new `## [v0.17.1]` section for accuracy.
- Target branch: `v0.17`.
