### PR TITLE
feat(scheduler): workload-centric eviction metrics

### DIFF
--- a/.changes/unreleased/changed-20260830-161635.yaml
+++ b/.changes/unreleased/changed-20260830-161635.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: |-
+  Replace pod-group eviction metrics with workload labels and an events counter

--- a/.changes/unreleased/changed-20260902-102655.yaml
+++ b/.changes/unreleased/changed-20260902-102655.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: |-
-  Initialize eviction metrics only for enabled eviction actions

--- a/.changes/unreleased/changed-20260902-102655.yaml
+++ b/.changes/unreleased/changed-20260902-102655.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: |-
+  Initialize eviction metrics only for enabled eviction actions

--- a/docs/metrics/METRICS.md
+++ b/docs/metrics/METRICS.md
@@ -58,7 +58,8 @@ Metrics related to the core scheduling algorithm performance, task lifecycle, an
 | `scenarios_simulation_by_action` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `action` | Cumulative count of simulation scenarios run by each action during scheduling decisions. |
 | `scenarios_filtered_by_action` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `action` | Cumulative count of simulation scenarios filtered/rejected by each action. |
 | `total_preemption_attempts` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service` | Cumulative total of preemption attempts across the entire cluster lifetime. |
-| `pod_group_evicted_pods_total` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `podgroup`, `uid`, `nodepool`, `action` | Cumulative count of pods evicted per pod group, tracked by nodepool and action. |
+| `pod_group_evicted_pods_total` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `podgroup`, `nodepool`, `action`, `owner_group`, `owner_kind`, `owner_name`, `owner_uid`, `subgroup` | Cumulative count of pods evicted per pod group, workload, and leaf subgroup. |
+| `pod_group_eviction_events_total` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `podgroup`, `nodepool`, `action`, `owner_group`, `owner_kind`, `owner_name`, `owner_uid` | Cumulative count of committed eviction decisions per affected pod group. |
 | `scenario_search_jobs_total` | Counter | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `action`, `result`, `reduced_budget` | Cumulative count of jobs considered by bounded scenario search, grouped by scheduling action, terminal search result, and whether the job ran after the action budget was reduced. |
 | `scenario_search_action_budget_configured_seconds` | Gauge | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service`, `action` | Configured scenario-search budget for each scheduling action in seconds. A value of 0 means unlimited. |
 | `scenario_search_job_budget_configured_seconds` | Gauge | `endpoint`, `instance`, `job`, `namespace`, `pod`, `service` | Configured per-job scenario-search budget in seconds. A value of 0 means unlimited. |
@@ -103,4 +104,8 @@ Business/Resource Labels:
 - **`OnSession`**: Session lifecycle phase (`OnSessionOpen` or `OnSessionClose`)
 - **`podgroup`**: PodGroup resource identifier
 - **`nodepool`**: Node pool identifier for resource allocation
-- **`uid`**: Unique identifier (pod group UID)
+- **`owner_group`**: API group of the top-level workload object
+- **`owner_kind`**: Kind of the top-level workload object
+- **`owner_name`**: Name of the top-level workload object
+- **`owner_uid`**: UID of the top-level workload object
+- **`subgroup`**: Leaf SubGroup of an evicted pod; empty for flat PodGroups

--- a/pkg/scheduler/actions/factory.go
+++ b/pkg/scheduler/actions/factory.go
@@ -29,9 +29,9 @@ import (
 )
 
 func InitDefaultActions() {
-	framework.RegisterAction(reclaim.New())
+	framework.RegisterEvictionAction(reclaim.New())
 	framework.RegisterAction(allocate.New())
-	framework.RegisterAction(preempt.New())
-	framework.RegisterAction(consolidation.New())
-	framework.RegisterAction(stalegangeviction.New())
+	framework.RegisterEvictionAction(preempt.New())
+	framework.RegisterEvictionAction(consolidation.New())
+	framework.RegisterEvictionAction(stalegangeviction.New())
 }

--- a/pkg/scheduler/actions/stalegangeviction/stalegangeviction.go
+++ b/pkg/scheduler/actions/stalegangeviction/stalegangeviction.go
@@ -75,6 +75,7 @@ func handleStaleJob(ssn *framework.Session, job *podgroup_info.PodGroupInfo) {
 		Action:           string(framework.StaleGangEviction),
 		Preemptor:        nil,
 	}
+	evicted := false
 	for _, task := range tasksToEvict {
 		reason := api.GetGangEvictionMessage(task, job)
 		if err := ssn.Evict(task, reason, evictionMetadata); err != nil {
@@ -82,8 +83,12 @@ func handleStaleJob(ssn *framework.Session, job *podgroup_info.PodGroupInfo) {
 				task.Namespace, task.Name, job.Name, err)
 			continue
 		}
+		evicted = true
 		log.InfraLogger.V(3).Infof("Evicted task: <%v/%v> due its job being a stale job, its status: <%v>",
 			task.Namespace, task.Name, task.Status)
+	}
+	if evicted {
+		ssn.Cache.RecordPodGroupEvictionEvent(job, evictionMetadata.Action)
 	}
 }
 

--- a/pkg/scheduler/actions/stalegangeviction/stalegangeviction_test.go
+++ b/pkg/scheduler/actions/stalegangeviction/stalegangeviction_test.go
@@ -315,7 +315,8 @@ func TestStaleGangEviction(t *testing.T) {
 				},
 				Mocks: &test_utils.TestMock{
 					CacheRequirements: &test_utils.CacheMocking{
-						NumberOfCacheEvictions: 3,
+						NumberOfCacheEvictions:         3,
+						NumberOfPodGroupEvictionEvents: 1,
 					},
 				},
 			},

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -116,18 +116,21 @@ func registerSchedulerPodInformer(informerFactory informers.SharedInformerFactor
 func registerPodGroupEvictionMetricHandlers(
 	informer k8scache.SharedIndexInformer,
 	nodePoolLabelKey string,
+	evictionActionNames []string,
 ) error {
 	_, err := informer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			if podGroup, ok := obj.(*enginev2alpha2.PodGroup); ok {
-				metrics.InitPodGroupEvictionMetrics(podGroup, nodePoolLabelKey)
+				metrics.InitPodGroupEvictionMetrics(podGroup, nodePoolLabelKey, evictionActionNames)
 			}
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			oldPodGroup, oldOK := oldObj.(*enginev2alpha2.PodGroup)
 			newPodGroup, newOK := newObj.(*enginev2alpha2.PodGroup)
 			if oldOK && newOK {
-				metrics.InitPodGroupEvictionMetricsOnUpdate(oldPodGroup, newPodGroup, nodePoolLabelKey)
+				metrics.InitPodGroupEvictionMetricsOnUpdate(
+					oldPodGroup, newPodGroup, nodePoolLabelKey, evictionActionNames,
+				)
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -170,6 +173,7 @@ type SchedulerCacheParams struct {
 	UpdatePodEvictionCondition  bool
 	StuckInReleasingThreshold   time.Duration
 	DiscoveryClient             discovery.DiscoveryInterface
+	EvictionActionNames         []string
 }
 
 type SchedulerCache struct {
@@ -238,6 +242,7 @@ func newSchedulerCache(schedulerCacheParams *SchedulerCacheParams) (*SchedulerCa
 	if err := registerPodGroupEvictionMetricHandlers(
 		sc.kubeAiSchedulerInformerFactory.Scheduling().V2alpha2().PodGroups().Informer(),
 		sc.schedulingNodePoolParams.NodePoolLabelKey,
+		schedulerCacheParams.EvictionActionNames,
 	); err != nil {
 		return nil, fmt.Errorf("failed to register PodGroup eviction metric handlers: %w", err)
 	}

--- a/pkg/scheduler/cache/cache.go
+++ b/pkg/scheduler/cache/cache.go
@@ -68,6 +68,7 @@ import (
 	k8splugins "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/k8s_internal/plugins"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/metrics"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/utils"
 )
 
 func init() {
@@ -110,6 +111,41 @@ func registerSchedulerPodInformer(informerFactory informers.SharedInformerFactor
 			filterFailedPods,
 		)
 	})
+}
+
+func registerPodGroupEvictionMetricHandlers(
+	informer k8scache.SharedIndexInformer,
+	nodePoolLabelKey string,
+) error {
+	_, err := informer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			if podGroup, ok := obj.(*enginev2alpha2.PodGroup); ok {
+				metrics.InitPodGroupEvictionMetrics(podGroup, nodePoolLabelKey)
+			}
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldPodGroup, oldOK := oldObj.(*enginev2alpha2.PodGroup)
+			newPodGroup, newOK := newObj.(*enginev2alpha2.PodGroup)
+			if oldOK && newOK {
+				metrics.InitPodGroupEvictionMetricsOnUpdate(oldPodGroup, newPodGroup, nodePoolLabelKey)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			podGroup, ok := obj.(*enginev2alpha2.PodGroup)
+			if !ok {
+				tombstone, tombstoneOK := obj.(k8scache.DeletedFinalStateUnknown)
+				if !tombstoneOK {
+					return
+				}
+				podGroup, ok = tombstone.Obj.(*enginev2alpha2.PodGroup)
+				if !ok {
+					return
+				}
+			}
+			metrics.DeletePodGroupEvictionMetrics(podGroup.Namespace, podGroup.Name)
+		},
+	})
+	return err
 }
 
 // New returns a Cache implementation.
@@ -199,6 +235,12 @@ func newSchedulerCache(schedulerCacheParams *SchedulerCacheParams) (*SchedulerCa
 		return nil, fmt.Errorf("failed to set scheduler pod transform: %w", err)
 	}
 	sc.kubeAiSchedulerInformerFactory = kubeaischedulerinfo.NewSharedInformerFactory(sc.kubeAiSchedulerClient, 0)
+	if err := registerPodGroupEvictionMetricHandlers(
+		sc.kubeAiSchedulerInformerFactory.Scheduling().V2alpha2().PodGroups().Informer(),
+		sc.schedulingNodePoolParams.NodePoolLabelKey,
+	); err != nil {
+		return nil, fmt.Errorf("failed to register PodGroup eviction metric handlers: %w", err)
+	}
 
 	if err := featuregates.SetDRAFeatureGate(schedulerCacheParams.DiscoveryClient); err != nil {
 		return nil, fmt.Errorf("failed to determine dynamic resource allocation availability: %w", err)
@@ -295,12 +337,20 @@ func (sc *SchedulerCache) Evict(evictedPod *v1.Pod, evictedPodGroup *podgroup_in
 	return nil
 }
 
+func (sc *SchedulerCache) RecordPodGroupEvictionEvent(podGroup *podgroup_info.PodGroupInfo, action string) {
+	nodepool := utils.GetNodePoolNameFromLabels(
+		podGroup.PodGroup.Labels,
+		sc.schedulingNodePoolParams.NodePoolLabelKey,
+	)
+	metrics.IncPodGroupEvictionEvents(podGroup.PodGroup, nodepool, action)
+}
+
 func (sc *SchedulerCache) evict(evictedPod *v1.Pod, evictedPodGroup *enginev2alpha2.PodGroup, evictionMetadata eviction_info.EvictionMetadata, message string) {
 	sc.workersWaitGroup.Add(1)
 	go func() {
 		defer sc.workersWaitGroup.Done()
 		if len(message) > 0 {
-			sc.StatusUpdater.Evicted(evictedPodGroup, evictionMetadata, message)
+			sc.StatusUpdater.Evicted(evictedPod, evictedPodGroup, evictionMetadata, message)
 		}
 
 		log.InfraLogger.V(6).Infof("Evicting pod %v/%v, reason: %v, message: %v",

--- a/pkg/scheduler/cache/cache_mock.go
+++ b/pkg/scheduler/cache/cache_mock.go
@@ -149,6 +149,18 @@ func (mr *MockCacheMockRecorder) RecordJobStatusEvent(job, resolveDetailedFitErr
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordJobStatusEvent", reflect.TypeOf((*MockCache)(nil).RecordJobStatusEvent), job, resolveDetailedFitErrors)
 }
 
+// RecordPodGroupEvictionEvent mocks base method.
+func (m *MockCache) RecordPodGroupEvictionEvent(job *podgroup_info.PodGroupInfo, action string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RecordPodGroupEvictionEvent", job, action)
+}
+
+// RecordPodGroupEvictionEvent indicates an expected call of RecordPodGroupEvictionEvent.
+func (mr *MockCacheMockRecorder) RecordPodGroupEvictionEvent(job, action any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordPodGroupEvictionEvent", reflect.TypeOf((*MockCache)(nil).RecordPodGroupEvictionEvent), job, action)
+}
+
 // Run mocks base method.
 func (m *MockCache) Run(stopCh <-chan struct{}) {
 	m.ctrl.T.Helper()

--- a/pkg/scheduler/cache/interface.go
+++ b/pkg/scheduler/cache/interface.go
@@ -41,6 +41,7 @@ type Cache interface {
 	WaitForCacheSync(stopCh <-chan struct{})
 	Bind(podInfo *pod_info.PodInfo, hostname string, bindRequestAnnotations map[string]string, predictedNUMAZones []schedulingv1alpha2.NUMAZonePlacement) error
 	Evict(ssnPod *v1.Pod, job *podgroup_info.PodGroupInfo, evictionMetadata eviction_info.EvictionMetadata, message string) error
+	RecordPodGroupEvictionEvent(job *podgroup_info.PodGroupInfo, action string)
 	RecordJobStatusEvent(
 		job *podgroup_info.PodGroupInfo,
 		resolveDetailedFitErrors func(

--- a/pkg/scheduler/cache/status_updater/default_status_updater.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater.go
@@ -100,6 +100,7 @@ func New(
 }
 
 func (su *defaultStatusUpdater) Evicted(
+	evictedPod *v1.Pod,
 	evictedPodGroup *enginev2alpha2.PodGroup,
 	evictionMetadata eviction_info.EvictionMetadata,
 	message string,
@@ -119,11 +120,10 @@ func (su *defaultStatusUpdater) Evicted(
 
 	nodepool := utils.GetNodePoolNameFromLabels(evictedPodGroup.Labels, su.nodePoolLabelKey)
 	metrics.IncPodGroupEvictedPods(
-		evictedPodGroup.Name,
-		evictedPodGroup.Namespace,
-		string(evictedPodGroup.UID),
+		evictedPodGroup,
 		nodepool,
 		evictionMetadata.Action,
+		evictedPod.Labels[commonconstants.SubGroupLabelKey],
 	)
 }
 

--- a/pkg/scheduler/cache/status_updater/default_status_updater_test.go
+++ b/pkg/scheduler/cache/status_updater/default_status_updater_test.go
@@ -1086,7 +1086,7 @@ func makeEvictionPodGroup(t *testing.T, suffix string) *enginev2alpha2.PodGroup 
 	}
 }
 
-func getEvictedPodsCounterValue(t *testing.T, name, namespace, uid, nodepool, action string) (float64, bool) {
+func getEvictedPodsCounterValue(t *testing.T, expectedLabels map[string]string) (float64, bool) {
 	families, err := prometheus.DefaultGatherer.Gather()
 	require.NoError(t, err)
 	for _, family := range families {
@@ -1098,8 +1098,7 @@ func getEvictedPodsCounterValue(t *testing.T, name, namespace, uid, nodepool, ac
 			for _, lp := range m.GetLabel() {
 				labels[lp.GetName()] = lp.GetValue()
 			}
-			if labels["podgroup"] == name && labels["namespace"] == namespace &&
-				labels["uid"] == uid && labels["nodepool"] == nodepool && labels["action"] == action {
+			if assert.ObjectsAreEqualValues(expectedLabels, labels) {
 				return m.GetCounter().GetValue(), true
 			}
 		}
@@ -1122,20 +1121,57 @@ func TestEvicted_IncrementsCounterByOnePerCall(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			pg := makeEvictionPodGroup(t, tc.name)
+			pg.Annotations = map[string]string{
+				commonconstants.TopOwnerMetadataKey: "group: jobset.x-k8s.io\nkind: JobSet\nname: train-x\nuid: owner-uid\n",
+			}
+			pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{commonconstants.SubGroupLabelKey: "workers"},
+			}}
 			statusUpdater := newEvictionTestStatusUpdater()
 
 			for i := 0; i < tc.callCount; i++ {
-				statusUpdater.Evicted(pg, eviction_info.EvictionMetadata{
+				statusUpdater.Evicted(pod, pg, eviction_info.EvictionMetadata{
 					Action:           "preempt",
 					EvictionGangSize: tc.evictionGangSize,
 				}, "evicted")
 			}
 
-			value, found := getEvictedPodsCounterValue(t, pg.Name, pg.Namespace, string(pg.UID), "default", "preempt")
+			value, found := getEvictedPodsCounterValue(t, map[string]string{
+				"action":      "preempt",
+				"namespace":   pg.Namespace,
+				"nodepool":    "default",
+				"owner_group": "jobset.x-k8s.io",
+				"owner_kind":  "JobSet",
+				"owner_name":  "train-x",
+				"owner_uid":   "owner-uid",
+				"podgroup":    pg.Name,
+				"subgroup":    "workers",
+			})
 			require.True(t, found, "counter sample was not emitted")
 			assert.Equal(t, float64(tc.callCount), value)
 		})
 	}
+}
+
+func TestEvicted_UsesEmptyWorkloadLabelsWhenOwnerMetadataIsMissing(t *testing.T) {
+	pg := makeEvictionPodGroup(t, "no-owner")
+	statusUpdater := newEvictionTestStatusUpdater()
+
+	statusUpdater.Evicted(&v1.Pod{}, pg, eviction_info.EvictionMetadata{Action: "reclaim"}, "evicted")
+
+	value, found := getEvictedPodsCounterValue(t, map[string]string{
+		"action":      "reclaim",
+		"namespace":   pg.Namespace,
+		"nodepool":    "default",
+		"owner_group": "",
+		"owner_kind":  "",
+		"owner_name":  "",
+		"owner_uid":   "",
+		"podgroup":    pg.Name,
+		"subgroup":    "",
+	})
+	require.True(t, found, "counter sample was not emitted")
+	assert.Equal(t, float64(1), value)
 }
 
 func TestEvicted_EmitsAnnotatedEventWithMetadata(t *testing.T) {
@@ -1145,7 +1181,7 @@ func TestEvicted_EmitsAnnotatedEventWithMetadata(t *testing.T) {
 	kubeAiSchedClient := kubeaischedfake.NewSimpleClientset()
 	statusUpdater := New(kubeClient, kubeAiSchedClient, recorder, 1, false, nodePoolLabelKey)
 
-	statusUpdater.Evicted(pg, eviction_info.EvictionMetadata{
+	statusUpdater.Evicted(&v1.Pod{}, pg, eviction_info.EvictionMetadata{
 		Action:           "preempt",
 		EvictionGangSize: 5,
 		Preemptor:        &types.NamespacedName{Namespace: "preemptor-ns", Name: "preemptor"},

--- a/pkg/scheduler/cache/status_updater/interface.go
+++ b/pkg/scheduler/cache/status_updater/interface.go
@@ -19,7 +19,7 @@ type PodGroupsSync interface {
 
 type Interface interface {
 	PodGroupsSync
-	Evicted(evictedPodGroup *enginev2alpha2.PodGroup, evictionMetadata eviction_info.EvictionMetadata, message string)
+	Evicted(evictedPod *v1.Pod, evictedPodGroup *enginev2alpha2.PodGroup, evictionMetadata eviction_info.EvictionMetadata, message string)
 	PreBind(pod *v1.Pod)
 	Bound(pod *v1.Pod, hostname string, bindError error, nodePoolName string) error
 	Pipelined(pod *v1.Pod, message string)

--- a/pkg/scheduler/framework/plugins.go
+++ b/pkg/scheduler/framework/plugins.go
@@ -45,12 +45,22 @@ func GetPluginBuilder(name string) (PluginBuilder, bool) {
 
 // Action management
 var actionMap = map[ActionType]Action{}
+var evictionActionNames = map[ActionType]struct{}{}
 
 func RegisterAction(act Action) {
 	pluginMutex.Lock()
 	defer pluginMutex.Unlock()
 
 	actionMap[act.Name()] = act
+	delete(evictionActionNames, act.Name())
+}
+
+func RegisterEvictionAction(act Action) {
+	pluginMutex.Lock()
+	defer pluginMutex.Unlock()
+
+	actionMap[act.Name()] = act
+	evictionActionNames[act.Name()] = struct{}{}
 }
 
 func GetAction(name string) (Action, bool) {
@@ -59,4 +69,12 @@ func GetAction(name string) (Action, bool) {
 
 	act, found := actionMap[ActionType(name)]
 	return act, found
+}
+
+func IsEvictionAction(name ActionType) bool {
+	pluginMutex.Lock()
+	defer pluginMutex.Unlock()
+
+	_, found := evictionActionNames[name]
+	return found
 }

--- a/pkg/scheduler/framework/statement.go
+++ b/pkg/scheduler/framework/statement.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 )
 
@@ -570,6 +571,16 @@ func (s *Statement) Commit() error {
 	}
 
 	var err error
+	type evictionEventKey struct {
+		podGroup common_info.PodGroupID
+		action   string
+	}
+	committedEvictions := map[evictionEventKey]*podgroup_info.PodGroupInfo{}
+	defer func() {
+		for key, podGroup := range committedEvictions {
+			s.ssn.Cache.RecordPodGroupEvictionEvent(podGroup, key.action)
+		}
+	}()
 
 	log.InfraLogger.V(4).Infof("Committing operations ...")
 	for i, op := range s.operations {
@@ -585,6 +596,9 @@ func (s *Statement) Commit() error {
 			if err = s.commitEvict(taskInfo, evictOp); err != nil {
 				log.InfraLogger.Errorf("Failed to evict task <%v/%v>, error: <%v>",
 					taskInfo.Namespace, taskInfo.Name, err)
+			} else {
+				key := evictionEventKey{podGroup: taskInfo.Job, action: evictOp.evictionMetadata.Action}
+				committedEvictions[key] = s.ssn.ClusterInfo.PodGroupInfos[taskInfo.Job]
 			}
 		case pipeline:
 			log.InfraLogger.V(4).Infof("Pipelining task: %v/%v", taskInfo.Namespace, taskInfo.Name)

--- a/pkg/scheduler/framework/statement_test.go
+++ b/pkg/scheduler/framework/statement_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	resourceapi "k8s.io/api/resource/v1"
 
 	schedulingv1alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v1alpha2"
@@ -19,11 +21,58 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	schedulercache "github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/cache"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/jobs_fake"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/nodes_fake"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/test_utils/tasks_fake"
 )
+
+func TestStatementCommitRecordsOneEvictionEventPerPodGroup(t *testing.T) {
+	vectorMap := resource_info.NewResourceVectorMap()
+	jobs, tasksToNodes, _ := jobs_fake.BuildJobsAndTasksMaps([]*jobs_fake.TestJobBasic{
+		{
+			Name:      "victim-a",
+			QueueName: "queue0",
+			Tasks: []*tasks_fake.TestTaskBasic{
+				{State: pod_status.Running, NodeName: "node0"},
+				{State: pod_status.Running, NodeName: "node0"},
+			},
+		},
+		{
+			Name:      "victim-b",
+			QueueName: "queue0",
+			Tasks: []*tasks_fake.TestTaskBasic{
+				{State: pod_status.Running, NodeName: "node0"},
+			},
+		},
+	}, vectorMap)
+	nodes := nodes_fake.BuildNodesInfoMap(map[string]nodes_fake.TestNodeBasic{
+		"node0": {CPUMillis: 10000},
+	}, tasksToNodes, nil, vectorMap)
+
+	controller := gomock.NewController(t)
+	cache := schedulercache.NewMockCache(controller)
+	cache.EXPECT().Evict(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(3)
+	cache.EXPECT().RecordPodGroupEvictionEvent(jobs["victim-a"], "preempt").Times(1)
+	cache.EXPECT().RecordPodGroupEvictionEvent(jobs["victim-b"], "preempt").Times(1)
+
+	session := &Session{ClusterInfo: &api.ClusterInfo{
+		PodGroupInfos: jobs,
+		Nodes:         nodes,
+	}, Cache: cache}
+	statement := session.Statement()
+	for _, job := range jobs {
+		for _, task := range job.GetAllPodsMap() {
+			require.NoError(t, statement.Evict(task, "evicted", eviction_info.EvictionMetadata{
+				Action:           "preempt",
+				EvictionGangSize: 3,
+			}))
+		}
+	}
+
+	require.NoError(t, statement.Commit())
+}
 
 func TestStatement_Evict_Unevict(t *testing.T) {
 	type args struct {

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -25,6 +25,11 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto" // auto-registry collectors in default registry
+	"gopkg.in/yaml.v3"
+
+	enginev2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/utils"
 )
 
 const (
@@ -33,7 +38,19 @@ const (
 
 	// OnSessionClose label
 	OnSessionClose = "OnSessionClose"
+
+	reclaimAction           = "reclaim"
+	preemptAction           = "preempt"
+	consolidationAction     = "consolidation"
+	staleGangEvictionAction = "stalegangeviction"
 )
+
+var evictionActions = []string{
+	reclaimAction,
+	preemptAction,
+	consolidationAction,
+	staleGangEvictionAction,
+}
 
 var (
 	currentAction                                  string
@@ -57,6 +74,7 @@ var (
 	queueGPUUsage                                  *prometheus.GaugeVec
 	usageQueryLatency                              *prometheus.HistogramVec
 	podGroupEvictedPodsTotal                       *prometheus.CounterVec
+	podGroupEvictionEventsTotal                    *prometheus.CounterVec
 	scenarioSearchJobsTotal                        *prometheus.CounterVec
 	scenarioSearchActionBudgetConfiguredSeconds    *prometheus.GaugeVec
 	scenarioSearchJobBudgetConfiguredSeconds       prometheus.Gauge
@@ -214,7 +232,20 @@ func InitMetrics(namespace string) {
 			Namespace: namespace,
 			Name:      "pod_group_evicted_pods_total",
 			Help:      "Total number of pods evicted per pod group",
-		}, []string{"podgroup", "namespace", "uid", "nodepool", "action"})
+		}, []string{
+			"podgroup", "namespace", "nodepool", "action",
+			"owner_group", "owner_kind", "owner_name", "owner_uid", "subgroup",
+		})
+
+	podGroupEvictionEventsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "pod_group_eviction_events_total",
+			Help:      "Total number of committed eviction decisions per pod group",
+		}, []string{
+			"podgroup", "namespace", "nodepool", "action",
+			"owner_group", "owner_kind", "owner_name", "owner_uid",
+		})
 
 	scenarioSearchJobsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -365,9 +396,110 @@ func RegisterPreemptionAttempts() {
 	preemptionAttempts.Inc()
 }
 
+type topOwnerMetadata struct {
+	Name  string `yaml:"name"`
+	UID   string `yaml:"uid"`
+	Group string `yaml:"group"`
+	Kind  string `yaml:"kind"`
+}
+
+func ownerLabels(podGroup *enginev2alpha2.PodGroup) topOwnerMetadata {
+	var metadata topOwnerMetadata
+	if value := podGroup.Annotations[commonconstants.TopOwnerMetadataKey]; value != "" {
+		if err := yaml.Unmarshal([]byte(value), &metadata); err != nil {
+			return topOwnerMetadata{}
+		}
+	}
+	return metadata
+}
+
+func podGroupEvictionLabels(podGroup *enginev2alpha2.PodGroup, nodepool, action string) []string {
+	owner := ownerLabels(podGroup)
+	return []string{
+		podGroup.Name,
+		podGroup.Namespace,
+		nodepool,
+		action,
+		owner.Group,
+		owner.Kind,
+		owner.Name,
+		owner.UID,
+	}
+}
+
 // IncPodGroupEvictedPods records a single pod eviction for a pod group.
-func IncPodGroupEvictedPods(name, namespace, uid, nodepool, action string) {
-	podGroupEvictedPodsTotal.WithLabelValues(name, namespace, uid, nodepool, action).Inc()
+func IncPodGroupEvictedPods(podGroup *enginev2alpha2.PodGroup, nodepool, action, subgroup string) {
+	labels := append(podGroupEvictionLabels(podGroup, nodepool, action), subgroup)
+	podGroupEvictedPodsTotal.WithLabelValues(labels...).Inc()
+}
+
+// IncPodGroupEvictionEvents records a committed eviction decision for a pod group.
+func IncPodGroupEvictionEvents(podGroup *enginev2alpha2.PodGroup, nodepool, action string) {
+	podGroupEvictionEventsTotal.WithLabelValues(podGroupEvictionLabels(podGroup, nodepool, action)...).Inc()
+}
+
+// InitPodGroupEvictionMetrics creates zero-valued series before the first eviction.
+func InitPodGroupEvictionMetrics(podGroup *enginev2alpha2.PodGroup, nodePoolLabelKey string) {
+	nodepool := utils.GetNodePoolNameFromLabels(podGroup.Labels, nodePoolLabelKey)
+	subgroups := leafSubgroups(podGroup.Spec.SubGroups)
+	for _, action := range evictionActions {
+		eventLabels := podGroupEvictionLabels(podGroup, nodepool, action)
+		podGroupEvictionEventsTotal.WithLabelValues(eventLabels...).Add(0)
+		for _, subgroup := range subgroups {
+			podLabels := append(eventLabels, subgroup)
+			podGroupEvictedPodsTotal.WithLabelValues(podLabels...).Add(0)
+		}
+	}
+}
+
+// InitPodGroupEvictionMetricsOnUpdate creates series for leaf subgroups added after creation.
+func InitPodGroupEvictionMetricsOnUpdate(
+	oldPodGroup, newPodGroup *enginev2alpha2.PodGroup,
+	nodePoolLabelKey string,
+) {
+	oldLeaves := make(map[string]struct{}, len(oldPodGroup.Spec.SubGroups))
+	for _, subgroup := range leafSubgroups(oldPodGroup.Spec.SubGroups) {
+		oldLeaves[subgroup] = struct{}{}
+	}
+
+	nodepool := utils.GetNodePoolNameFromLabels(newPodGroup.Labels, nodePoolLabelKey)
+	for _, subgroup := range leafSubgroups(newPodGroup.Spec.SubGroups) {
+		if _, exists := oldLeaves[subgroup]; exists {
+			continue
+		}
+		for _, action := range evictionActions {
+			labels := append(podGroupEvictionLabels(newPodGroup, nodepool, action), subgroup)
+			podGroupEvictedPodsTotal.WithLabelValues(labels...).Add(0)
+		}
+	}
+}
+
+func leafSubgroups(subgroups []enginev2alpha2.SubGroup) []string {
+	if len(subgroups) == 0 {
+		return []string{""}
+	}
+
+	parents := make(map[string]struct{}, len(subgroups))
+	for _, subgroup := range subgroups {
+		if subgroup.Parent != nil {
+			parents[*subgroup.Parent] = struct{}{}
+		}
+	}
+
+	leaves := make([]string, 0, len(subgroups))
+	for _, subgroup := range subgroups {
+		if _, isParent := parents[subgroup.Name]; !isParent {
+			leaves = append(leaves, subgroup.Name)
+		}
+	}
+	return leaves
+}
+
+// DeletePodGroupEvictionMetrics removes all series for a deleted pod group.
+func DeletePodGroupEvictionMetrics(namespace, podGroup string) {
+	labels := prometheus.Labels{"namespace": namespace, "podgroup": podGroup}
+	podGroupEvictedPodsTotal.DeletePartialMatch(labels)
+	podGroupEvictionEventsTotal.DeletePartialMatch(labels)
 }
 
 func IncScenarioSearchJobs[A ~string](action A, result string, reducedBudget bool) {

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -38,19 +38,7 @@ const (
 
 	// OnSessionClose label
 	OnSessionClose = "OnSessionClose"
-
-	reclaimAction           = "reclaim"
-	preemptAction           = "preempt"
-	consolidationAction     = "consolidation"
-	staleGangEvictionAction = "stalegangeviction"
 )
-
-var evictionActions = []string{
-	reclaimAction,
-	preemptAction,
-	consolidationAction,
-	staleGangEvictionAction,
-}
 
 var (
 	currentAction                                  string
@@ -439,10 +427,14 @@ func IncPodGroupEvictionEvents(podGroup *enginev2alpha2.PodGroup, nodepool, acti
 }
 
 // InitPodGroupEvictionMetrics creates zero-valued series before the first eviction.
-func InitPodGroupEvictionMetrics(podGroup *enginev2alpha2.PodGroup, nodePoolLabelKey string) {
+func InitPodGroupEvictionMetrics(
+	podGroup *enginev2alpha2.PodGroup,
+	nodePoolLabelKey string,
+	evictionActionNames []string,
+) {
 	nodepool := utils.GetNodePoolNameFromLabels(podGroup.Labels, nodePoolLabelKey)
 	subgroups := leafSubgroups(podGroup.Spec.SubGroups)
-	for _, action := range evictionActions {
+	for _, action := range evictionActionNames {
 		eventLabels := podGroupEvictionLabels(podGroup, nodepool, action)
 		podGroupEvictionEventsTotal.WithLabelValues(eventLabels...).Add(0)
 		for _, subgroup := range subgroups {
@@ -456,6 +448,7 @@ func InitPodGroupEvictionMetrics(podGroup *enginev2alpha2.PodGroup, nodePoolLabe
 func InitPodGroupEvictionMetricsOnUpdate(
 	oldPodGroup, newPodGroup *enginev2alpha2.PodGroup,
 	nodePoolLabelKey string,
+	evictionActionNames []string,
 ) {
 	oldLeaves := make(map[string]struct{}, len(oldPodGroup.Spec.SubGroups))
 	for _, subgroup := range leafSubgroups(oldPodGroup.Spec.SubGroups) {
@@ -467,7 +460,7 @@ func InitPodGroupEvictionMetricsOnUpdate(
 		if _, exists := oldLeaves[subgroup]; exists {
 			continue
 		}
-		for _, action := range evictionActions {
+		for _, action := range evictionActionNames {
 			labels := append(podGroupEvictionLabels(newPodGroup, nodepool, action), subgroup)
 			podGroupEvictedPodsTotal.WithLabelValues(labels...).Add(0)
 		}

--- a/pkg/scheduler/metrics/metrics_test.go
+++ b/pkg/scheduler/metrics/metrics_test.go
@@ -4,6 +4,7 @@
 package metrics
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -11,6 +12,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	enginev2alpha2 "github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 )
 
 // TestQueueLabels exercises the three queue identification labels emitted on
@@ -60,6 +66,122 @@ func TestQueueLabels(t *testing.T) {
 			ResetQueueUsage()
 		})
 	}
+}
+
+func TestPodGroupEvictionMetricLifecycle(t *testing.T) {
+	tag := fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano())
+	podGroup := &enginev2alpha2.PodGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pg-" + tag,
+			Namespace: "ns-" + tag,
+			Labels:    map[string]string{"node-pool": "gpu"},
+			Annotations: map[string]string{
+				commonconstants.TopOwnerMetadataKey: "group: jobset.x-k8s.io\nkind: JobSet\nname: train-x\nuid: owner-uid\n",
+			},
+		},
+		Spec: enginev2alpha2.PodGroupSpec{
+			SubGroups: []enginev2alpha2.SubGroup{
+				{Name: "pipeline", MinSubGroup: ptr.To(int32(2))},
+				{Name: "prefill", Parent: ptr.To("pipeline"), MinMember: ptr.To(int32(1))},
+				{Name: "decode", Parent: ptr.To("pipeline"), MinMember: ptr.To(int32(1))},
+			},
+		},
+	}
+
+	InitPodGroupEvictionMetrics(podGroup, "node-pool")
+	require.Equal(t, 8, countMetricsForPodGroup(t, "pod_group_evicted_pods_total", podGroup))
+	require.Equal(t, 4, countMetricsForPodGroup(t, "pod_group_eviction_events_total", podGroup))
+	require.Zero(t, metricValueForLabels(t, "pod_group_evicted_pods_total", map[string]string{
+		"podgroup":  podGroup.Name,
+		"namespace": podGroup.Namespace,
+		"action":    "preempt",
+		"subgroup":  "prefill",
+	}))
+
+	IncPodGroupEvictedPods(podGroup, "gpu", "preempt", "prefill")
+	InitPodGroupEvictionMetrics(podGroup, "node-pool")
+	require.Equal(t, float64(1), metricValueForLabels(t, "pod_group_evicted_pods_total", map[string]string{
+		"podgroup":  podGroup.Name,
+		"namespace": podGroup.Namespace,
+		"action":    "preempt",
+		"subgroup":  "prefill",
+	}))
+
+	oldPodGroup := podGroup.DeepCopy()
+	podGroup.Spec.SubGroups = append(podGroup.Spec.SubGroups,
+		enginev2alpha2.SubGroup{Name: "postprocessor", Parent: ptr.To("pipeline"), MinMember: ptr.To(int32(1))})
+	InitPodGroupEvictionMetricsOnUpdate(oldPodGroup, podGroup, "node-pool")
+	require.Equal(t, 12, countMetricsForPodGroup(t, "pod_group_evicted_pods_total", podGroup))
+	require.Equal(t, float64(1), metricValueForLabels(t, "pod_group_evicted_pods_total", map[string]string{
+		"podgroup":  podGroup.Name,
+		"namespace": podGroup.Namespace,
+		"action":    "preempt",
+		"subgroup":  "prefill",
+	}))
+
+	DeletePodGroupEvictionMetrics(podGroup.Namespace, podGroup.Name)
+	require.Zero(t, countMetricsForPodGroup(t, "pod_group_evicted_pods_total", podGroup))
+	require.Zero(t, countMetricsForPodGroup(t, "pod_group_eviction_events_total", podGroup))
+}
+
+func countMetricsForPodGroup(t *testing.T, familyName string, podGroup *enginev2alpha2.PodGroup) int {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	count := 0
+	for _, family := range families {
+		if family.GetName() != familyName {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			labels := labelsForMetric(metric)
+			if labels["podgroup"] == podGroup.Name && labels["namespace"] == podGroup.Namespace {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func metricValueForLabels(t *testing.T, familyName string, expected map[string]string) float64 {
+	t.Helper()
+	family := metricFamily(t, familyName)
+	for _, metric := range family.GetMetric() {
+		labels := labelsForMetric(metric)
+		matches := true
+		for name, value := range expected {
+			if labels[name] != value {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return metric.GetCounter().GetValue()
+		}
+	}
+	t.Fatalf("metric %s with labels %v not found", familyName, expected)
+	return 0
+}
+
+func metricFamily(t *testing.T, name string) *dto.MetricFamily {
+	t.Helper()
+	families, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() == name {
+			return family
+		}
+	}
+	t.Fatalf("metric family %s not found", name)
+	return nil
+}
+
+func labelsForMetric(metric *dto.Metric) map[string]string {
+	labels := map[string]string{}
+	for _, pair := range metric.GetLabel() {
+		labels[pair.GetName()] = pair.GetValue()
+	}
+	return labels
 }
 
 func TestScenarioSearchMetricWrappersUseExpectedLabels(t *testing.T) {

--- a/pkg/scheduler/metrics/metrics_test.go
+++ b/pkg/scheduler/metrics/metrics_test.go
@@ -87,10 +87,11 @@ func TestPodGroupEvictionMetricLifecycle(t *testing.T) {
 			},
 		},
 	}
+	evictionActionNames := []string{"preempt"}
 
-	InitPodGroupEvictionMetrics(podGroup, "node-pool")
-	require.Equal(t, 8, countMetricsForPodGroup(t, "pod_group_evicted_pods_total", podGroup))
-	require.Equal(t, 4, countMetricsForPodGroup(t, "pod_group_eviction_events_total", podGroup))
+	InitPodGroupEvictionMetrics(podGroup, "node-pool", evictionActionNames)
+	require.Equal(t, 2, countMetricsForPodGroup(t, "pod_group_evicted_pods_total", podGroup))
+	require.Equal(t, 1, countMetricsForPodGroup(t, "pod_group_eviction_events_total", podGroup))
 	require.Zero(t, metricValueForLabels(t, "pod_group_evicted_pods_total", map[string]string{
 		"podgroup":  podGroup.Name,
 		"namespace": podGroup.Namespace,
@@ -99,7 +100,7 @@ func TestPodGroupEvictionMetricLifecycle(t *testing.T) {
 	}))
 
 	IncPodGroupEvictedPods(podGroup, "gpu", "preempt", "prefill")
-	InitPodGroupEvictionMetrics(podGroup, "node-pool")
+	InitPodGroupEvictionMetrics(podGroup, "node-pool", evictionActionNames)
 	require.Equal(t, float64(1), metricValueForLabels(t, "pod_group_evicted_pods_total", map[string]string{
 		"podgroup":  podGroup.Name,
 		"namespace": podGroup.Namespace,
@@ -110,8 +111,8 @@ func TestPodGroupEvictionMetricLifecycle(t *testing.T) {
 	oldPodGroup := podGroup.DeepCopy()
 	podGroup.Spec.SubGroups = append(podGroup.Spec.SubGroups,
 		enginev2alpha2.SubGroup{Name: "postprocessor", Parent: ptr.To("pipeline"), MinMember: ptr.To(int32(1))})
-	InitPodGroupEvictionMetricsOnUpdate(oldPodGroup, podGroup, "node-pool")
-	require.Equal(t, 12, countMetricsForPodGroup(t, "pod_group_evicted_pods_total", podGroup))
+	InitPodGroupEvictionMetricsOnUpdate(oldPodGroup, podGroup, "node-pool", evictionActionNames)
+	require.Equal(t, 3, countMetricsForPodGroup(t, "pod_group_evicted_pods_total", podGroup))
 	require.Equal(t, float64(1), metricValueForLabels(t, "pod_group_evicted_pods_total", map[string]string{
 		"podgroup":  podGroup.Name,
 		"namespace": podGroup.Namespace,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -57,6 +57,12 @@ func NewScheduler(
 	schedulerParams *conf.SchedulerParams,
 	mux *http.ServeMux,
 ) (*Scheduler, error) {
+	configuredActions, err := conf_util.GetActionsFromConfig(schedulerConf)
+	if err != nil {
+		return nil, err
+	}
+	evictionActionNames := getEvictionActionNames(configuredActions)
+
 	kubeClient, kubeAiSchedulerClient := newClients(config)
 
 	nrtClient, err := nrtclientset.NewForConfig(config)
@@ -95,6 +101,7 @@ func NewScheduler(
 		UpdatePodEvictionCondition:  schedulerParams.UpdatePodEvictionCondition,
 		StuckInReleasingThreshold:   schedulerParams.StuckInReleasingThreshold,
 		DiscoveryClient:             discoveryClient,
+		EvictionActionNames:         evictionActionNames,
 	}
 
 	schedulerCache, err := schedcache.New(schedulerCacheParams)
@@ -111,6 +118,16 @@ func NewScheduler(
 	}
 
 	return scheduler, nil
+}
+
+func getEvictionActionNames(actions []framework.Action) []string {
+	actionNames := make([]string, 0, len(actions))
+	for _, action := range actions {
+		if framework.IsEvictionAction(action.Name()) {
+			actionNames = append(actionNames, string(action.Name()))
+		}
+	}
+	return actionNames
 }
 
 func (s *Scheduler) Run(stopCh <-chan struct{}) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,24 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/actions"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/conf"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/conf_util"
+)
+
+func TestGetEvictionActionNames(t *testing.T) {
+	actions.InitDefaultActions()
+	configuredActions, err := conf_util.GetActionsFromConfig(&conf.SchedulerConfiguration{
+		Actions: "allocate, reclaim, stalegangeviction",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"reclaim", "stalegangeviction"}, getEvictionActionNames(configuredActions))
+}

--- a/pkg/scheduler/test_utils/test_utils.go
+++ b/pkg/scheduler/test_utils/test_utils.go
@@ -69,9 +69,10 @@ type TestMock struct {
 }
 
 type CacheMocking struct {
-	NumberOfCacheBinds      int
-	NumberOfCacheEvictions  int
-	NumberOfPipelineActions int
+	NumberOfCacheBinds             int
+	NumberOfCacheEvictions         int
+	NumberOfPodGroupEvictionEvents int
+	NumberOfPipelineActions        int
 }
 
 type GPUMetricMocks struct {
@@ -414,6 +415,13 @@ func GetTestCacheMock(
 	if cacheRequirements.NumberOfCacheEvictions != 0 {
 		cacheMock.EXPECT().Evict(Any(), Any(), Any(), Any()).
 			Return(nil).MaxTimes(cacheRequirements.NumberOfCacheEvictions)
+	}
+
+	if cacheRequirements.NumberOfPodGroupEvictionEvents != 0 {
+		cacheMock.EXPECT().RecordPodGroupEvictionEvent(Any(), Any()).
+			Times(cacheRequirements.NumberOfPodGroupEvictionEvents)
+	} else {
+		cacheMock.EXPECT().RecordPodGroupEvictionEvent(Any(), Any()).AnyTimes()
 	}
 
 	if cacheRequirements.NumberOfPipelineActions != 0 {


### PR DESCRIPTION
## Description

Replace the PodGroup eviction metric with a workload-centric shape so operators can answer "how disrupted has this JobSet/Workspace been" with standard PromQL.

- Relabel `kai_pod_group_evicted_pods_total` with owner and leaf-subgroup labels, drop the PodGroup `uid` label, and pre-initialize series at 0 on PodGroup observe so `rate()` / `increase()` work from the first eviction.
- Add `kai_pod_group_eviction_events_total`, incremented once per committed decision per affected PodGroup (statement commit for preempt/reclaim/consolidation; explicit record for stale-gang eviction).
- Seed zero-series from the configured eviction actions only (`RegisterEvictionAction`), not allocate.

Fixes #1573

## Related Issues

Fixes #1573
Design: `docs/developer/designs/eviction-metrics/README.md` (#1604)

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

Yes. `kai_pod_group_evicted_pods_total` drops the PodGroup `uid` label and adds `owner_group`, `owner_kind`, `owner_name`, `owner_uid`, and `subgroup`. Panels that filter on `uid` will return empty. Queries that `sum by (...)` without those labels keep working.

## Additional Notes

Pre-initialization and delete handlers are wired on the PodGroup informer. Event increments must not fire for rolled-back statement operations; `Statement.Commit` records only after a successful `commitEvict`.

## Test Plan

- [ ] Unit: `go test ./pkg/scheduler/metrics ./pkg/scheduler/framework ./pkg/scheduler/scheduler ./pkg/scheduler/cache/status_updater ./pkg/scheduler/actions/stalegangeviction`
- [ ] Confirm a PodGroup that is observed then evicted once produces non-zero `increase()` on both counters
- [ ] Confirm a gang eviction of N pods on one PG increments pods by N and events by 1
- [ ] Confirm stale-gang eviction increments events with `action="stalegangeviction"`
- [ ] Confirm PodGroup delete drops the series (`DeletePartialMatch`)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workload owner and subgroup labels to pod-group eviction metrics.
  * Added an eviction-events counter tracking committed eviction decisions per pod group.
  * Eviction metrics now initialize, update, and clean up as pod groups change.
* **Bug Fixes**
  * Stale-job evictions now record an event when at least one pod is successfully evicted.
* **Documentation**
  * Updated metrics documentation with the new labels and counter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->