### PR TITLE
fix(binder): cancel resource reservation sync

### DIFF
--- a/cmd/binder/app/app.go
+++ b/cmd/binder/app/app.go
@@ -146,10 +146,11 @@ func (app *App) RegisterPlugins(plugins *plugins.BinderPlugins) {
 func (app *App) Run(ctx context.Context) error {
 	var err error
 	go func() {
-		app.manager.GetCache().WaitForCacheSync(context.Background())
+		if !app.manager.GetCache().WaitForCacheSync(ctx) {
+			return
+		}
 		setupLog.Info("syncing resource reservation")
-		err := app.rrs.Sync(context.Background())
-		if err != nil {
+		if err := app.rrs.Sync(ctx); err != nil && ctx.Err() == nil {
 			setupLog.Error(err, "unable to sync resource reservation")
 			panic(err)
 		}


### PR DESCRIPTION
## Description

Propagate Binder run cancellation to cache synchronization and resource-reservation synchronization. Prevents EnvTest teardown work from outliving its Binder context.

## Related Issues

Fixes #2118

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (not needed; cancellation propagation only)
- [ ] Updated documentation (not needed)
- [x] Applied the `skip-changelog` label.

## Breaking Changes

None.

## Additional Notes

Verified with `go test ./cmd/binder/app`.