### PR TITLE
feat(chart): Support configuring `queueLabelSelector` for admission

### DIFF
--- a/.changes/unreleased/Added-20260906-092531.yaml
+++ b/.changes/unreleased/Added-20260906-092531.yaml
@@ -1,0 +1,6 @@
+kind: Added
+body: Wire admission.queueLabelSelector Helm value into kai-config (was hardcoded false)
+time: 2026-09-06T09:25:31.739155259+01:00
+custom:
+    Author: dttung2905
+    Issue: ""

--- a/deployments/kai-scheduler/templates/_helpers.tpl
+++ b/deployments/kai-scheduler/templates/_helpers.tpl
@@ -278,7 +278,7 @@ spec:
       {{- end }}
     gpuSharing: {{ .Values.global.gpuSharing | default false }}
     blockNvidiaVisibleDevices: {{ .Values.global.blockNvidiaVisibleDevices | default false }}
-    queueLabelSelector: false
+    queueLabelSelector: {{ .Values.admission.queueLabelSelector | default false }}
     webhook:
       port: 443
       targetPort: {{ .Values.admission.ports.webhookPort | default 9443 }}

--- a/deployments/kai-scheduler/tests/admission_queue_label_selector_test.yaml
+++ b/deployments/kai-scheduler/tests/admission_queue_label_selector_test.yaml
@@ -1,0 +1,26 @@
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+suite: test admission queueLabelSelector configuration
+
+set:
+  kaiConfigDeployer:
+    enabled: false
+  kaiConfig:
+    render: true
+templates:
+  - kai-config.yaml
+tests:
+  - it: should render queueLabelSelector false by default
+    asserts:
+      - equal:
+          path: spec.admission.queueLabelSelector
+          value: false
+
+  - it: should render queueLabelSelector true when admission.queueLabelSelector is set
+    set:
+      admission.queueLabelSelector: true
+    asserts:
+      - equal:
+          path: spec.admission.queueLabelSelector
+          value: true

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -241,6 +241,8 @@ admission:
     metricsPort: 8080
     probePort: 8081
   cdi: false
+  # Enable queue label MatchExpression on admission webhooks (requires pods to have the queue label).
+  queueLabelSelector: false
   gpuFractionRuntimeClassName: nvidia
   affinity: {}
   podDisruptionBudget:

--- a/deployments/kai-scheduler/values.yaml
+++ b/deployments/kai-scheduler/values.yaml
@@ -241,7 +241,9 @@ admission:
     metricsPort: 8080
     probePort: 8081
   cdi: false
-  # Enable queue label MatchExpression on admission webhooks (requires pods to have the queue label).
+  # When true, admission webhooks only run in namespaces labeled with
+  # global.queueLabelKey (default kai.scheduler/queue). When false (default),
+  # webhooks apply to all namespaces except kube-system and the KAI install ns.
   queueLabelSelector: false
   gpuFractionRuntimeClassName: nvidia
   affinity: {}


### PR DESCRIPTION


## Description

Currently, the queueLabelSelector defaults to `false` and not configurable. It means the webhook apply to every namespaces except kube-system.
I'm making it configurable. When true, the operator adds another namespaceSelector rule: the namespace must have the queue label key (default kai.scheduler/queue from global.queueLabelKey). Only those namespaces get webhook admission.


## Related Issues

Fixes #

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [ ] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
