### PR TITLE
feat(release): publish images.yaml manifest as a release asset

### DIFF
--- a/.changes/unreleased/added-20260907-144137.yaml
+++ b/.changes/unreleased/added-20260907-144137.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: |-
+  Publish images.yaml manifest with per-platform image digests as a release asset

--- a/.github/workflows/push-artifacts.yaml
+++ b/.github/workflows/push-artifacts.yaml
@@ -102,3 +102,38 @@ jobs:
           for f in bin/*-amd64 bin/*-arm64; do
             go version -m "$f" | grep -q 'GOFIPS140=v1.0.0' || { echo "$f is not FIPS-enabled"; exit 1; }
           done
+
+  publish-images-manifest:
+    name: Publish images.yaml
+    needs: [build-and-push, build-and-push-fips]
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Extract package version from tag
+        run: |
+          PACKAGE_VERSION=${GITHUB_REF_NAME}
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
+          echo $PACKAGE_VERSION
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate images.yaml
+        run: make images-manifest VERSION=$PACKAGE_VERSION DOCKER_REPO_BASE=${{ env.DOCKER_REGISTRY }}
+
+      - name: Upload images.yaml as Release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.PACKAGE_VERSION }}
+          files: images.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,11 @@ changelog-preview: changie ## Preview the next release section without writing a
 	@test -n "$(VERSION)" || { echo "VERSION is required, e.g. make changelog-preview VERSION=v0.17.0"; exit 1; }
 	$(CHANGIE) batch $(VERSION) --dry-run
 
+.PHONY: images-manifest
+images-manifest: ## Generate images.yaml for a release. Usage: make images-manifest VERSION=v0.17.0 DOCKER_REPO_BASE=ghcr.io/kai-scheduler/kai-scheduler
+	@test -n "$(VERSION)" || { echo "VERSION is required, e.g. make images-manifest VERSION=v0.17.0"; exit 1; }
+	bash hack/generate-images-manifest.sh "$(VERSION)" "$(DOCKER_REPO_BASE)" "$(SERVICE_NAMES) crd-upgrader" > images.yaml
+
 
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"

--- a/hack/generate-images-manifest.sh
+++ b/hack/generate-images-manifest.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright 2026 NVIDIA CORPORATION
+# SPDX-License-Identifier: Apache-2.0
+
+# Generate a flat images.yaml manifest listing every pushed image (component x
+# FIPS variant x platform) for a release. Requires the caller to already be
+# logged in to the registry (docker login) so `docker buildx imagetools
+# inspect` can read the pushed manifest lists.
+#
+# Usage: hack/generate-images-manifest.sh vX.Y.Z <registry> "<component1> <component2> ..." > images.yaml
+set -euo pipefail
+
+VERSION="${1:-}"
+REGISTRY="${2:-}"
+COMPONENTS="${3:-}"
+if [ -z "$VERSION" ] || [ -z "$REGISTRY" ] || [ -z "$COMPONENTS" ]; then
+  echo "usage: $0 vX.Y.Z <registry> \"<space-separated components>\"" >&2
+  exit 1
+fi
+
+echo "version: ${VERSION}"
+echo "images:"
+for component in $COMPONENTS; do
+  for tag in "${VERSION}" "${VERSION}-fips"; do
+    ref="${REGISTRY}/${component}:${tag}"
+    docker buildx imagetools inspect "$ref" --raw | jq -r --arg component "$component" --arg uri "$ref" '
+      .manifests[]
+      | select(.platform.os == "linux")
+      | select(.platform.architecture == "amd64" or .platform.architecture == "arm64")
+      | "  - component: \($component)\n    os: \(.platform.os)\n    arch: \(.platform.architecture)\n    uri: \($uri)\n    digest: \(.digest)"
+    '
+  done
+done

--- a/hack/setup-e2e-cluster.sh
+++ b/hack/setup-e2e-cluster.sh
@@ -121,6 +121,13 @@ helm install prometheus prometheus-community/kube-prometheus-stack --namespace m
     --set "alertmanager.enabled=false" \
     --set "grafana.enabled=false" \
     --set "prometheus.enabled=false" \
+    --set "kubeApiServer.enabled=false" \
+    --set "kubelet.enabled=false" \
+    --set "kubeControllerManager.enabled=false" \
+    --set "coreDns.enabled=false" \
+    --set "kubeEtcd.enabled=false" \
+    --set "kubeScheduler.enabled=false" \
+    --set "kubeProxy.enabled=false" \
     --wait
 
 # Install VPA and its prerequisites

--- a/hack/setup-e2e-cluster.sh
+++ b/hack/setup-e2e-cluster.sh
@@ -121,13 +121,6 @@ helm install prometheus prometheus-community/kube-prometheus-stack --namespace m
     --set "alertmanager.enabled=false" \
     --set "grafana.enabled=false" \
     --set "prometheus.enabled=false" \
-    --set "kubeApiServer.enabled=false" \
-    --set "kubelet.enabled=false" \
-    --set "kubeControllerManager.enabled=false" \
-    --set "coreDns.enabled=false" \
-    --set "kubeEtcd.enabled=false" \
-    --set "kubeScheduler.enabled=false" \
-    --set "kubeProxy.enabled=false" \
     --wait
 
 # Install VPA and its prerequisites


### PR DESCRIPTION
## Description

Publishes a flat, vendor-neutral `images.yaml` manifest as a GitHub Release asset (alongside the source tarballs), listing every image built for that release — one entry per component x FIPS variant x platform, with its registry URI and digest.

No `apiVersion`/`kind`/CRD-style envelope, no text added to release notes — just the file.

New `publish-images-manifest` job in `push-artifacts.yaml` (tag-triggered only, runs after both `build-and-push` and `build-and-push-fips` so digests reflect the actually-pushed images):
- `hack/generate-images-manifest.sh` — uses `docker buildx imagetools inspect --raw` + `jq` to pull per-platform digests for `linux/amd64`/`linux/arm64`, filtering out buildx attestation sub-manifests.
- `make images-manifest VERSION=... DOCKER_REPO_BASE=...` — wraps the script, following the existing `changelog-release` pattern; reuses `SERVICE_NAMES` + `crd-upgrader` as the component list so it can't drift from the actual build/push targets.
- Uploads via `softprops/action-gh-release@v2` with only `files:`/`tag_name:` set, so the release body is untouched.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None.

## Additional Notes

Verified locally: script syntax, jq filtering (attestation manifests excluded), end-to-end YAML output validated against the agreed schema, workflow YAML parses with correct `needs`/`if` gating. `make images-manifest` correctly reaches out to the registry and fails on a nonexistent test tag, confirming the wiring up to the network boundary. A full CI run (real tag push) is the remaining verification step, per plan.