### PR TITLE
fix(ci): disable control-plane ServiceMonitors and pin prometheus chart in e2e setup

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -96,9 +96,17 @@ runs:
         helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update
         helm repo update prometheus-community
         helm install prometheus prometheus-community/kube-prometheus-stack --namespace monitoring --create-namespace \
+        --version 90.0.0 \
         --set "alertmanager.enabled=false" \
         --set "grafana.enabled=false" \
         --set "prometheus.enabled=false" \
+        --set "kubeApiServer.enabled=false" \
+        --set "kubelet.enabled=false" \
+        --set "kubeControllerManager.enabled=false" \
+        --set "coreDns.enabled=false" \
+        --set "kubeEtcd.enabled=false" \
+        --set "kubeScheduler.enabled=false" \
+        --set "kubeProxy.enabled=false" \
         --wait
 
     - name: Set up Go

--- a/hack/setup-e2e-cluster.sh
+++ b/hack/setup-e2e-cluster.sh
@@ -121,6 +121,13 @@ helm install prometheus prometheus-community/kube-prometheus-stack --namespace m
     --set "alertmanager.enabled=false" \
     --set "grafana.enabled=false" \
     --set "prometheus.enabled=false" \
+    --set "kubeApiServer.enabled=false" \
+    --set "kubelet.enabled=false" \
+    --set "kubeControllerManager.enabled=false" \
+    --set "coreDns.enabled=false" \
+    --set "kubeEtcd.enabled=false" \
+    --set "kubeScheduler.enabled=false" \
+    --set "kubeProxy.enabled=false" \
     --wait
 
 # Install VPA and its prerequisites

--- a/hack/setup-e2e-cluster.sh
+++ b/hack/setup-e2e-cluster.sh
@@ -118,6 +118,7 @@ echo "Deploying Prometheus Operator..."
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update
 helm repo update prometheus-community
 helm install prometheus prometheus-community/kube-prometheus-stack --namespace monitoring --create-namespace \
+    --version 90.0.0 \
     --set "alertmanager.enabled=false" \
     --set "grafana.enabled=false" \
     --set "prometheus.enabled=false" \


### PR DESCRIPTION
## Description

`hack/setup-e2e-cluster.sh` installs `prometheus-community/kube-prometheus-stack` unpinned, so CI always tracks the latest chart. The latest release (90.0.0) added a validation guard (`_helpers.tpl:123-125`, `kube-prometheus-stack.prometheus.tokenSecretName`) requiring an auth Secret that's only created when `prometheus.enabled` and `prometheus.serviceAccount.create` are both true. This e2e setup intentionally sets `prometheus.enabled=false` (it only needs the Operator + CRDs for our own `scheduler`/`binder`/`queue-controller` ServiceMonitors — no Prometheus server ever runs to scrape anything), so installs started failing:

```
Error: INSTALLATION FAILED: execution error at (kube-prometheus-stack/templates/exporters/kubelet/servicemonitor.yaml:48:8):
The control-plane ServiceMonitors authenticate by default with the Secret created by prometheus.serviceAccount.createTokenSecret...
```

All 7 default-enabled control-plane components (`kubeApiServer`, `kubelet`, `kubeControllerManager`, `coreDns`, `kubeEtcd`, `kubeScheduler`, `kubeProxy`) carry the same unconditional default `authorization.credentials.name` pointing at that guarded secret in `values.yaml` — not just `kubelet`, which is just the one that happened to render first.

## Fix

- Disable those 7 components explicitly, same as `alertmanager`/`grafana`/`prometheus` are already disabled — none of them are actually scraped in this setup.
- Pin `--version 90.0.0` so an unrelated future chart release can't silently break e2e setup again.

Verified locally with `helm template` against the pinned version: fails without the fix, renders cleanly with it.

## Related Issues

Fixes #

## Checklist

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [ ] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None. CI/e2e tooling only.

## Additional Notes

Split out from #2124, where this was originally found blocking the e2e-matrix job for an unrelated PR.
