### PR TITLE
feat(podgrouper): For new deployments, use a single podGroup per deployment

### DIFF
--- a/.changes/unreleased/added-20260907-224417.yaml
+++ b/.changes/unreleased/added-20260907-224417.yaml
@@ -1,3 +1,6 @@
 kind: Added
 body: |-
-  Config to group all pods of a deployment under a single podgroup
+  Config to group all pods of a deployment under a single podgroup. From now on, this will be the grouping behavior for deployments by default.
+custom:
+    Author: davidLif
+    Issue: "2109"

--- a/.changes/unreleased/added-20260907-224417.yaml
+++ b/.changes/unreleased/added-20260907-224417.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: |-
+  Config to group all pods of a deployment under a single podgroup

--- a/.changes/unreleased/changed-20260908-161916.yaml
+++ b/.changes/unreleased/changed-20260908-161916.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: |-
-  Job batch-min-member annotation values below 1 are now rejected instead of silently applied

--- a/.changes/unreleased/changed-20260908-161916.yaml
+++ b/.changes/unreleased/changed-20260908-161916.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: |-
+  Job batch-min-member annotation values below 1 are now rejected instead of silently applied

--- a/cmd/podgrouper/app/app.go
+++ b/cmd/podgrouper/app/app.go
@@ -119,7 +119,7 @@ func NewWithScheme(mgrScheme *runtime.Scheme) (*App, error) {
 	}
 
 	defaultPluginsHub := pluginshub.NewDefaultPluginsHub(mgr.GetClient(), configs.SearchForLegacyPodGroups,
-		configs.KnativeGangSchedule, configs.GenericKartaFallback, configs.SchedulingQueueLabelKey, configs.NodePoolLabelKey,
+		configs.KnativeGangSchedule, configs.DeploymentGangSchedule, configs.GenericKartaFallback, configs.SchedulingQueueLabelKey, configs.NodePoolLabelKey,
 		configs.DefaultConfigPerTypeConfigMapName, configs.DefaultConfigPerTypeConfigMapNamespace)
 
 	app := &App{

--- a/cmd/podgrouper/app/options.go
+++ b/cmd/podgrouper/app/options.go
@@ -21,6 +21,7 @@ type Options struct {
 	MaxConcurrentReconciles                int
 	SearchForLegacyPodGroups               bool
 	KnativeGangSchedule                    bool
+	DeploymentGangSchedule                 bool
 	GenericKartaFallback                   bool
 	SchedulerName                          string
 	SchedulingQueueLabelKey                string
@@ -40,6 +41,7 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.IntVar(&o.MaxConcurrentReconciles, "max-concurrent-reconciles", 10, "Max concurrent reconciles")
 	fs.BoolVar(&o.SearchForLegacyPodGroups, "search-legacy-pg", true, "If this flag is enabled, try to find pod groups with legacy name format. If they exist, use the found pod groups instead of creating new once with current name format")
 	fs.BoolVar(&o.KnativeGangSchedule, "knative-gang-schedule", true, "Schedule knative revision as a gang. Defaults to true")
+	fs.BoolVar(&o.DeploymentGangSchedule, "deployment-gang-schedule", true, "Schedule all the pods of a deployment as a single gang. Defaults to true")
 	fs.BoolVar(&o.GenericKartaFallback, "generic-karta-fallback", true, "Enable Karta-backed generic pod grouping fallback for workload GVKs without native plugins")
 	fs.StringVar(&o.SchedulerName, "scheduler-name", constants.DefaultSchedulerName, "The name of the scheduler used to schedule pod groups")
 	fs.StringVar(&o.SchedulingQueueLabelKey, "queue-label-key", constants.DefaultQueueLabel, "Scheduling queue label key name")
@@ -55,6 +57,7 @@ func (o *Options) Configs() controllers.Configs {
 		MaxConcurrentReconciles:                o.MaxConcurrentReconciles,
 		SearchForLegacyPodGroups:               o.SearchForLegacyPodGroups,
 		KnativeGangSchedule:                    o.KnativeGangSchedule,
+		DeploymentGangSchedule:                 o.DeploymentGangSchedule,
 		GenericKartaFallback:                   o.GenericKartaFallback,
 		SchedulerName:                          o.SchedulerName,
 		SchedulingQueueLabelKey:                o.SchedulingQueueLabelKey,

--- a/deployments/kai-scheduler/crds/kai.scheduler_configs.yaml
+++ b/deployments/kai-scheduler/crds/kai.scheduler_configs.yaml
@@ -8000,6 +8000,11 @@ spec:
                           of the configmap that contains default priorities for pod
                           groups
                         type: string
+                      gangScheduleDeployment:
+                        description: GangScheduleDeployment specifies whether to group
+                          all the pods of a deployment under a single podgroup. Default
+                          is true. Disable to create a podgroup per pod.
+                        type: boolean
                       gangScheduleKnative:
                         description: GangScheduleKnative specifies whether to enable
                           gang scheduling for Knative revisions. Default is true.

--- a/docs/developer/pod-grouper.md
+++ b/docs/developer/pod-grouper.md
@@ -95,9 +95,14 @@ For Job resources, the Pod Grouper:
 - Sets the priority class of the PodGroup to "Train", to allow it to go over-quota
 
 ### Deployment Grouping
-Deployments are a special case:
-- A Pod Group is created per pod of the deployment
-- Default priority class for deployments is "Inference", as that's the usual use case for them
+For Deployment resources, the Pod Grouper:
+- Creates a single PodGroup per deployment, named `pg-<deployment-name>-<deployment-uid>`, with MinMember 1
+- Overrides MinMember from the `kai.scheduler/batch-min-member` annotation on the deployment
+- Sets the default priority class to "Inference", as that's the usual use case for them
+
+Setting `--deployment-gang-schedule=false` (`podGrouper.args.gangScheduleDeployment` in the KAI config) restores the
+legacy behavior of a PodGroup per pod. Deployments whose pods already belong to a PodGroup per pod keep that layout even
+when the flag is enabled, so that running pods aren't re-parented during an upgrade.
 
 ### MPI Job Grouping
 For MPI workloads:

--- a/pkg/apis/kai/v1/pod_grouper/pod_grouper.go
+++ b/pkg/apis/kai/v1/pod_grouper/pod_grouper.go
@@ -45,6 +45,10 @@ type Args struct {
 	// +kubebuilder:validation:Optional
 	GangScheduleKnative *bool `json:"gangScheduleKnative,omitempty"`
 
+	// GangScheduleDeployment specifies whether to group all the pods of a deployment under a single podgroup. Default is true. Disable to create a podgroup per pod.
+	// +kubebuilder:validation:Optional
+	GangScheduleDeployment *bool `json:"gangScheduleDeployment,omitempty"`
+
 	// GenericKartaFallback specifies whether to enable Karta-backed generic pod grouping fallback for workload GVKs without native plugins. Default is true.
 	// +kubebuilder:validation:Optional
 	GenericKartaFallback *bool `json:"genericKartaFallback,omitempty"`

--- a/pkg/apis/kai/v1/pod_grouper/zz_generated.deepcopy.go
+++ b/pkg/apis/kai/v1/pod_grouper/zz_generated.deepcopy.go
@@ -21,6 +21,11 @@ func (in *Args) DeepCopyInto(out *Args) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.GangScheduleDeployment != nil {
+		in, out := &in.GangScheduleDeployment, &out.GangScheduleDeployment
+		*out = new(bool)
+		**out = **in
+	}
 	if in.GenericKartaFallback != nil {
 		in, out := &in.GenericKartaFallback, &out.GenericKartaFallback
 		*out = new(bool)

--- a/pkg/operator/operands/pod_grouper/resources.go
+++ b/pkg/operator/operands/pod_grouper/resources.go
@@ -76,6 +76,9 @@ func buildArgsList(kaiConfig *kaiv1.Config) []string {
 	if config.Args.GangScheduleKnative != nil {
 		args = append(args, "--knative-gang-schedule="+strconv.FormatBool(*config.Args.GangScheduleKnative))
 	}
+	if config.Args.GangScheduleDeployment != nil {
+		args = append(args, "--deployment-gang-schedule="+strconv.FormatBool(*config.Args.GangScheduleDeployment))
+	}
 	if config.Args.GenericKartaFallback != nil {
 		args = append(args, "--generic-karta-fallback="+strconv.FormatBool(*config.Args.GenericKartaFallback))
 	}

--- a/pkg/operator/operands/pod_grouper/resources_test.go
+++ b/pkg/operator/operands/pod_grouper/resources_test.go
@@ -160,6 +160,31 @@ func TestBuildArgsList(t *testing.T) {
 			},
 		},
 		{
+			name: "with gang schedule deployment disabled",
+			config: &kaiv1.Config{
+				Spec: kaiv1.ConfigSpec{
+					Global: &kaiv1.GlobalConfig{
+						SchedulerName:    ptr.To(constants.DefaultSchedulerName),
+						QueueLabelKey:    ptr.To(constants.DefaultQueueLabel),
+						NodePoolLabelKey: ptr.To(constants.DefaultNodePoolLabelKey),
+					},
+					PodGrouper: &pod_grouper.PodGrouper{
+						Replicas: ptr.To(int32(1)),
+						Args: &pod_grouper.Args{
+							GangScheduleDeployment: ptr.To(false),
+						},
+						K8sClientConfig: &common.K8sClientConfig{},
+					},
+				},
+			},
+			expected: []string{
+				"--scheduler-name", constants.DefaultSchedulerName,
+				"--queue-label-key", constants.DefaultQueueLabel,
+				"--nodepool-label-key", constants.DefaultNodePoolLabelKey,
+				"--deployment-gang-schedule=false",
+			},
+		},
+		{
 			name: "with generic Karta fallback disabled",
 			config: &kaiv1.Config{
 				Spec: kaiv1.ConfigSpec{

--- a/pkg/podgrouper/pod_controller.go
+++ b/pkg/podgrouper/pod_controller.go
@@ -50,6 +50,7 @@ type Configs struct {
 	MaxConcurrentReconciles  int
 	SearchForLegacyPodGroups bool
 	KnativeGangSchedule      bool
+	DeploymentGangSchedule   bool
 	GenericKartaFallback     bool
 	SchedulerName            string
 	SchedulingQueueLabelKey  string

--- a/pkg/podgrouper/podgrouper/hub/hub.go
+++ b/pkg/podgrouper/podgrouper/hub/hub.go
@@ -109,7 +109,7 @@ func (ph *DefaultPluginsHub) getRegularPlugin(gvk metav1.GroupVersionKind) (grou
 }
 
 func NewDefaultPluginsHub(kubeClient client.Client, searchForLegacyPodGroups,
-	gangScheduleKnative, genericKartaFallback bool, queueLabelKey, nodePoolLabelKey string,
+	gangScheduleKnative, gangScheduleDeployment, genericKartaFallback bool, queueLabelKey, nodePoolLabelKey string,
 	defaultConfigPerTypeConfigMapName, defaultConfigPerTypeConfigMapNamespace string) *DefaultPluginsHub {
 	defaultGrouper := defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient)
 	defaultGrouper.SetDefaultConfigPerTypeConfigMapParams(defaultConfigPerTypeConfigMapName, defaultConfigPerTypeConfigMapNamespace)
@@ -133,7 +133,7 @@ func NewDefaultPluginsHub(kubeClient client.Client, searchForLegacyPodGroups,
 			Group:   "apps",
 			Version: "v1",
 			Kind:    "Deployment",
-		}: deployment.NewDeploymentGrouper(defaultGrouper),
+		}: deployment.NewDeploymentGrouper(kubeClient, defaultGrouper, gangScheduleDeployment),
 		{
 			Group:   "machinelearning.seldon.io",
 			Version: "v1alpha2",

--- a/pkg/podgrouper/podgrouper/hub/hub_test.go
+++ b/pkg/podgrouper/podgrouper/hub/hub_test.go
@@ -43,7 +43,7 @@ var _ = Describe("SupportedTypes", func() {
 		BeforeEach(func() {
 			kubeClient = fake.NewFakeClient()
 			hub = NewDefaultPluginsHub(
-				kubeClient, false, false, false, queueLabelKey, nodePoolLabelKey, "", "",
+				kubeClient, false, false, false, false, queueLabelKey, nodePoolLabelKey, "", "",
 			)
 		})
 
@@ -136,7 +136,7 @@ var _ = Describe("SupportedTypes", func() {
 			}
 			kubeClient = newHubFakeClientWithScheme(createHubTestKarta(gvk))
 			hub := NewDefaultPluginsHub(
-				kubeClient, false, false, true, queueLabelKey, nodePoolLabelKey, "", "",
+				kubeClient, false, false, false, true, queueLabelKey, nodePoolLabelKey, "", "",
 			)
 
 			plugin := hub.GetPodGrouperPlugin(gvk)
@@ -153,7 +153,7 @@ var _ = Describe("SupportedTypes", func() {
 			}
 			kubeClient = newHubFakeClientWithScheme(createHubTestKarta(gvk))
 			hub := NewDefaultPluginsHub(
-				kubeClient, false, false, true, queueLabelKey, nodePoolLabelKey, "", "",
+				kubeClient, false, false, false, true, queueLabelKey, nodePoolLabelKey, "", "",
 			)
 
 			plugin := hub.GetPodGrouperPlugin(gvk)
@@ -170,7 +170,7 @@ var _ = Describe("SupportedTypes", func() {
 			}
 			kubeClient = newHubFakeClientWithScheme(createHubTestKarta(gvk))
 			hub := NewDefaultPluginsHub(
-				kubeClient, false, false, false, queueLabelKey, nodePoolLabelKey, "", "",
+				kubeClient, false, false, false, false, queueLabelKey, nodePoolLabelKey, "", "",
 			)
 
 			plugin := hub.GetPodGrouperPlugin(gvk)
@@ -192,7 +192,7 @@ var _ = Describe("SupportedTypes", func() {
 			}
 			kubeClient := fake.NewFakeClient(statefulSet)
 			hub := NewDefaultPluginsHub(
-				kubeClient, false, false, false, queueLabelKey, nodePoolLabelKey, "", "",
+				kubeClient, false, false, false, false, queueLabelKey, nodePoolLabelKey, "", "",
 			)
 
 			runner := &unstructured.Unstructured{}
@@ -239,7 +239,7 @@ var _ = Describe("SupportedTypes", func() {
 		BeforeEach(func() {
 			kubeClient = fake.NewFakeClient()
 			hub = NewDefaultPluginsHub(
-				kubeClient, false, false, false, queueLabelKey, nodePoolLabelKey, "", "",
+				kubeClient, false, false, false, false, queueLabelKey, nodePoolLabelKey, "", "",
 			)
 		})
 

--- a/pkg/podgrouper/podgrouper/plugins/deployment/deployment_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/deployment/deployment_grouper.go
@@ -4,24 +4,43 @@
 package deployment
 
 import (
+	"context"
 	"fmt"
 
+	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgroup"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/minmember"
 )
 
+var logger = log.FromContext(context.Background())
+
 type DeploymentGrouper struct {
+	client       client.Client
+	gangSchedule bool
 	*defaultgrouper.DefaultGrouper
 }
 
-func NewDeploymentGrouper(defaultGrouper *defaultgrouper.DefaultGrouper) *DeploymentGrouper {
+func NewDeploymentGrouper(
+	client client.Client, defaultGrouper *defaultgrouper.DefaultGrouper, gangSchedule bool,
+) *DeploymentGrouper {
 	return &DeploymentGrouper{
-		defaultGrouper,
+		client:         client,
+		gangSchedule:   gangSchedule,
+		DefaultGrouper: defaultGrouper,
 	}
 }
 
@@ -39,15 +58,127 @@ func (dg *DeploymentGrouper) GetPodGroupMetadata(
 	if err != nil {
 		return nil, err
 	}
+	metadata.PriorityClassName = dg.CalcPodGroupPriorityClass(topOwner, pod, constants.InferencePriorityClass)
+
+	if !dg.gangSchedule {
+		return setPodGroupPerPod(metadata, pod), nil
+	}
+
+	legacy, err := dg.hasPodGroupPerPod(topOwner)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine gang behavior for deployment %s/%s and pod %s/%s: %w",
+			topOwner.GetNamespace(), topOwner.GetName(), pod.Namespace, pod.Name, err)
+	}
+	if legacy {
+		return setPodGroupPerPod(metadata, pod), nil
+	}
+
+	metadata.MinAvailable, err = minmember.FromAnnotations(topOwner, "Deployment", 1)
+	if err != nil {
+		return nil, err
+	}
+
+	return metadata, nil
+}
+
+func setPodGroupPerPod(metadata *podgroup.Metadata, pod *v1.Pod) *podgroup.Metadata {
 	metadata.Owner = metav1.OwnerReference{
 		APIVersion: pod.APIVersion,
 		Kind:       pod.Kind,
 		Name:       pod.GetName(),
 		UID:        pod.GetUID(),
 	}
-	metadata.PriorityClassName = dg.CalcPodGroupPriorityClass(topOwner, pod, constants.InferencePriorityClass)
-
 	metadata.Name = fmt.Sprintf("%s-%s-%s", constants.PodGroupNamePrefix, pod.GetName(), pod.GetUID())
+	metadata.MinAvailable = 1
+	return metadata
+}
 
-	return metadata, nil
+// hasPodGroupPerPod checks whether the deployment pods are already spread over a podgroup per pod. In that case, we
+// will maintain this behavior for the deployment, so that running pods aren't re-parented during an upgrade.
+func (dg *DeploymentGrouper) hasPodGroupPerPod(deployment *unstructured.Unstructured) (bool, error) {
+	selector, err := podSelector(deployment)
+	if err != nil {
+		return false, err
+	}
+	if selector == nil {
+		logger.V(1).Info("deployment has no pod selector, assuming no legacy podgroups", "deployment",
+			fmt.Sprintf("%s/%s", deployment.GetNamespace(), deployment.GetName()))
+		return false, nil
+	}
+
+	var pods v1.PodList
+	err = dg.client.List(context.Background(), &pods, client.InNamespace(deployment.GetNamespace()),
+		client.MatchingLabelsSelector{Selector: selector})
+	if err != nil {
+		return false, err
+	}
+
+	podGroups := make(map[string]bool)
+	for _, pod := range pods.Items {
+		podGroupName, found := pod.Annotations[commonconstants.PodGroupAnnotationForPod]
+		if !found {
+			continue
+		}
+
+		if podGroups[podGroupName] { // found 2 pods pointing to the same podgroup - it's a gang scheduled deployment
+			return false, nil
+		}
+
+		podGroups[podGroupName] = true
+	}
+
+	if len(podGroups) > 1 { // found more than 1 podgroup - is not a gang scheduled deployment
+		return true, nil
+	}
+
+	if len(podGroups) == 1 {
+		pgName := maps.Keys(podGroups)[0]
+
+		var podGroup v2alpha2.PodGroup
+		err = dg.client.Get(context.Background(),
+			types.NamespacedName{Namespace: deployment.GetNamespace(), Name: pgName}, &podGroup)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, fmt.Errorf("failed to get the only podgroup %s: %w", pgName, err)
+		}
+
+		if len(podGroup.OwnerReferences) == 0 {
+			return false, fmt.Errorf("podgroup %s has no owner references", pgName)
+		}
+
+		if podGroup.OwnerReferences[0].Kind == deployment.GetKind() {
+			return false, nil
+		}
+
+		if podGroup.OwnerReferences[0].Kind == "Pod" {
+			return true, nil
+		}
+
+		return false, fmt.Errorf("podgroup %s has unexpected owner reference: %v", pgName, podGroup.OwnerReferences[0])
+	}
+
+	return false, nil
+}
+
+// podSelector returns the deployment pod selector, or nil if the deployment doesn't select any pod. A nil selector is
+// returned rather than labels.Everything() to avoid listing unrelated pods in the namespace.
+func podSelector(deployment *unstructured.Unstructured) (labels.Selector, error) {
+	selectorMap, found, err := unstructured.NestedMap(deployment.Object, "spec", "selector")
+	if err != nil || !found {
+		return nil, err
+	}
+
+	labelSelector := &metav1.LabelSelector{}
+	if err = runtime.DefaultUnstructuredConverter.FromUnstructured(selectorMap, labelSelector); err != nil {
+		return nil, fmt.Errorf("failed to parse the selector of deployment %s/%s: %w",
+			deployment.GetNamespace(), deployment.GetName(), err)
+	}
+	if len(labelSelector.MatchLabels) == 0 && len(labelSelector.MatchExpressions) == 0 {
+		return nil, nil
+	}
+
+	return metav1.LabelSelectorAsSelector(labelSelector)
 }

--- a/pkg/podgrouper/podgrouper/plugins/deployment/deployment_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/deployment/deployment_test.go
@@ -7,11 +7,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/kai-scheduler/KAI-scheduler/pkg/apis/scheduling/v2alpha2"
+	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
 )
@@ -19,29 +26,45 @@ import (
 const (
 	queueLabelKey    = "kai.scheduler/queue"
 	nodePoolLabelKey = "kai.scheduler/node-pool"
+
+	deploymentName = "test_deployment"
+	namespace      = "test_namespace"
+	appLabelKey    = "app"
+	appLabelValue  = "test"
 )
 
-func TestGetPodGroupMetadata(t *testing.T) {
-	deployment := &unstructured.Unstructured{
+func testDeployment(annotations map[string]string) *unstructured.Unstructured {
+	unstructuredAnnotations := map[string]interface{}{
+		"test_annotation": "test_value",
+	}
+	for key, value := range annotations {
+		unstructuredAnnotations[key] = value
+	}
+
+	return &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"kind":       "Deployment",
 			"apiVersion": "apps/v1",
 			"metadata": map[string]interface{}{
-				"name":      "test_deployment",
-				"namespace": "test_namespace",
+				"name":      deploymentName,
+				"namespace": namespace,
 				"uid":       "1",
 				"labels": map[string]interface{}{
 					"test_label": "test_value",
 				},
-				"annotations": map[string]interface{}{
-					"test_annotation": "test_value",
-				},
+				"annotations": unstructuredAnnotations,
 			},
 			"spec": map[string]interface{}{
+				"selector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{
+						appLabelKey: appLabelValue,
+					},
+				},
 				"template": map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"labels": map[string]interface{}{
 							queueLabelKey: "test_queue",
+							appLabelKey:   appLabelValue,
 						},
 					},
 					"spec": map[string]interface{}{
@@ -54,36 +77,53 @@ func TestGetPodGroupMetadata(t *testing.T) {
 			},
 		},
 	}
+}
 
-	pod1 := &v1.Pod{
-		TypeMeta: metav1.TypeMeta{},
+func testPod(name, uid, podGroupName string) *v1.Pod {
+	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod-1",
-			Namespace: "test_namespace",
+			Name:      name,
+			Namespace: namespace,
 			Labels: map[string]string{
 				queueLabelKey: "test_queue",
+				appLabelKey:   appLabelValue,
 			},
-			UID: "3",
+			UID: apitypes.UID(uid),
 		},
-		Spec:   v1.PodSpec{},
-		Status: v1.PodStatus{},
 	}
+	if podGroupName != "" {
+		pod.Annotations = map[string]string{commonconstants.PodGroupAnnotationForPod: podGroupName}
+	}
+	return pod
+}
 
-	pod2 := &v1.Pod{
-		TypeMeta: metav1.TypeMeta{},
+func testPodGroup(name, ownerKind string) *v2alpha2.PodGroup {
+	return &v2alpha2.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pod-2",
-			Namespace: "test_namespace",
-			Labels: map[string]string{
-				queueLabelKey: "test_queue",
-			},
-			UID: "4",
+			Name:            name,
+			Namespace:       namespace,
+			OwnerReferences: []metav1.OwnerReference{{Kind: ownerKind, Name: "owner"}},
 		},
-		Spec:   v1.PodSpec{},
-		Status: v1.PodStatus{},
 	}
+}
 
-	grouper := NewDeploymentGrouper(defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient()))
+func newTestClient(objects ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = v1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = schedulingv1.AddToScheme(scheme)
+	_ = v2alpha2.AddToScheme(scheme)
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func TestGetPodGroupMetadataPerPod(t *testing.T) {
+	deployment := testDeployment(nil)
+	pod1 := testPod("pod-1", "3", "")
+	pod2 := testPod("pod-2", "4", "")
+
+	grouper := NewDeploymentGrouper(newTestClient(),
+		defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, fake.NewFakeClient()), false)
+
 	metadata, err := grouper.GetPodGroupMetadata(deployment, pod1)
 	assert.Nil(t, err)
 	assert.Equal(t, "pg-pod-1-3", metadata.Name)
@@ -96,4 +136,144 @@ func TestGetPodGroupMetadata(t *testing.T) {
 	assert.Equal(t, "pg-pod-2-4", metadata2.Name)
 	assert.Equal(t, constants.InferencePriorityClass, metadata2.PriorityClassName)
 	assert.Equal(t, "test_queue", metadata2.Queue)
+}
+
+func TestGetPodGroupMetadataGangSchedule(t *testing.T) {
+	type testData struct {
+		name                 string
+		gangSchedule         bool
+		annotations          map[string]string
+		existingPods         []*v1.Pod
+		existingPodGroups    []*v2alpha2.PodGroup
+		expectedError        bool
+		expectedPodGroupName string
+		expectedOwnerName    string
+		expectedMinAvailable int32
+	}
+
+	tests := []testData{
+		{
+			name:                 "gang schedule disabled",
+			gangSchedule:         false,
+			expectedPodGroupName: "pg-pod-1-3",
+			expectedOwnerName:    "pod-1",
+			expectedMinAvailable: 1,
+		},
+		{
+			name:                 "gang schedule enabled, no existing pod groups",
+			gangSchedule:         true,
+			expectedPodGroupName: "pg-test_deployment-1",
+			expectedOwnerName:    deploymentName,
+			expectedMinAvailable: 1,
+		},
+		{
+			name:         "gang schedule enabled, legacy pod groups per pod",
+			gangSchedule: true,
+			existingPods: []*v1.Pod{
+				testPod("old-pod-1", "10", "pg-old-pod-1-10"),
+				testPod("old-pod-2", "11", "pg-old-pod-2-11"),
+			},
+			existingPodGroups: []*v2alpha2.PodGroup{
+				testPodGroup("pg-old-pod-1-10", "Pod"),
+				testPodGroup("pg-old-pod-2-11", "Pod"),
+			},
+			expectedPodGroupName: "pg-pod-1-3",
+			expectedOwnerName:    "pod-1",
+			expectedMinAvailable: 1,
+		},
+		{
+			name:         "gang schedule enabled, single legacy pod group owned by a pod",
+			gangSchedule: true,
+			existingPods: []*v1.Pod{
+				testPod("old-pod-1", "10", "pg-old-pod-1-10"),
+			},
+			existingPodGroups: []*v2alpha2.PodGroup{
+				testPodGroup("pg-old-pod-1-10", "Pod"),
+			},
+			expectedPodGroupName: "pg-pod-1-3",
+			expectedOwnerName:    "pod-1",
+			expectedMinAvailable: 1,
+		},
+		{
+			name:         "gang schedule enabled, existing deployment pod group",
+			gangSchedule: true,
+			existingPods: []*v1.Pod{
+				testPod("old-pod-1", "10", "pg-test_deployment-1"),
+				testPod("old-pod-2", "11", "pg-test_deployment-1"),
+			},
+			existingPodGroups: []*v2alpha2.PodGroup{
+				testPodGroup("pg-test_deployment-1", "Deployment"),
+			},
+			expectedPodGroupName: "pg-test_deployment-1",
+			expectedOwnerName:    deploymentName,
+			expectedMinAvailable: 1,
+		},
+		{
+			name:                 "min member override",
+			gangSchedule:         true,
+			annotations:          map[string]string{constants.MinMemberOverrideKey: "3"},
+			expectedPodGroupName: "pg-test_deployment-1",
+			expectedOwnerName:    deploymentName,
+			expectedMinAvailable: 3,
+		},
+		{
+			name:         "min member override ignored for legacy pod groups",
+			gangSchedule: true,
+			annotations:  map[string]string{constants.MinMemberOverrideKey: "3"},
+			existingPods: []*v1.Pod{
+				testPod("old-pod-1", "10", "pg-old-pod-1-10"),
+				testPod("old-pod-2", "11", "pg-old-pod-2-11"),
+			},
+			existingPodGroups: []*v2alpha2.PodGroup{
+				testPodGroup("pg-old-pod-1-10", "Pod"),
+				testPodGroup("pg-old-pod-2-11", "Pod"),
+			},
+			expectedPodGroupName: "pg-pod-1-3",
+			expectedOwnerName:    "pod-1",
+			expectedMinAvailable: 1,
+		},
+		{
+			name:          "unparsable min member override",
+			gangSchedule:  true,
+			annotations:   map[string]string{constants.MinMemberOverrideKey: "not-a-number"},
+			expectedError: true,
+		},
+		{
+			name:          "min member override below one",
+			gangSchedule:  true,
+			annotations:   map[string]string{constants.MinMemberOverrideKey: "0"},
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := testPod("pod-1", "3", "")
+
+			var objects []client.Object
+			for _, existingPod := range test.existingPods {
+				objects = append(objects, existingPod)
+			}
+			for _, existingPodGroup := range test.existingPodGroups {
+				objects = append(objects, existingPodGroup)
+			}
+			kubeClient := newTestClient(objects...)
+
+			grouper := NewDeploymentGrouper(kubeClient,
+				defaultgrouper.NewDefaultGrouper(queueLabelKey, nodePoolLabelKey, kubeClient), test.gangSchedule)
+
+			metadata, err := grouper.GetPodGroupMetadata(testDeployment(test.annotations), pod)
+			if test.expectedError {
+				assert.NotNil(t, err)
+				return
+			}
+
+			assert.Nil(t, err)
+			assert.Equal(t, test.expectedPodGroupName, metadata.Name)
+			assert.Equal(t, test.expectedOwnerName, metadata.Owner.Name)
+			assert.Equal(t, test.expectedMinAvailable, metadata.MinAvailable)
+			assert.Equal(t, constants.InferencePriorityClass, metadata.PriorityClassName)
+			assert.Equal(t, "test_queue", metadata.Queue)
+		})
+	}
 }

--- a/pkg/podgrouper/podgrouper/plugins/job/job_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/job/job_grouper.go
@@ -6,7 +6,6 @@ package job
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -20,6 +19,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgroup"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/minmember"
 )
 
 type K8sJobGrouper struct {
@@ -59,7 +59,7 @@ func (g *K8sJobGrouper) GetPodGroupMetadata(topOwner *unstructured.Unstructured,
 		return nil, err
 	}
 
-	minMember, err := calcMinMember(topOwner, pod, legacy)
+	minMember, err := calcMinMember(topOwner, legacy)
 	if err != nil {
 		return nil, err
 	}
@@ -102,20 +102,10 @@ func (g *K8sJobGrouper) calcPodGroupName(topOwner *unstructured.Unstructured, po
 	return newName, false, nil
 }
 
-func calcMinMember(topOwner *unstructured.Unstructured, pod *v1.Pod, legacy bool) (int32, error) {
+func calcMinMember(topOwner *unstructured.Unstructured, legacy bool) (int32, error) {
 	if legacy {
 		return 1, nil
 	}
 
-	override, found := topOwner.GetAnnotations()[constants.MinMemberOverrideKey]
-	if !found {
-		return 1, nil
-	}
-
-	minMember, err := strconv.ParseInt(override, 10, 32)
-	if err != nil {
-		return 0, fmt.Errorf("invalid min-member annotation value: %w", err)
-	}
-
-	return int32(minMember), nil
+	return minmember.FromAnnotations(topOwner, "Job", 1)
 }

--- a/pkg/podgrouper/podgrouper/plugins/job/job_grouper_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/job/job_grouper_test.go
@@ -341,6 +341,8 @@ func TestGetPodGroupMetadata_MinMemberOverrideInvalid(t *testing.T) {
 	}{
 		{"non-numeric", "abc"},
 		{"non-int", "1.5"},
+		{"zero", "0"},
+		{"negative", "-1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -354,7 +356,7 @@ func TestGetPodGroupMetadata_MinMemberOverrideInvalid(t *testing.T) {
 						"uid":       "1234-5678",
 						"labels":    map[string]interface{}{},
 						"annotations": map[string]interface{}{
-							"kai.scheduler/batch-min-member": "invalid",
+							"kai.scheduler/batch-min-member": tt.annotation,
 						},
 					},
 					"spec": map[string]interface{}{},

--- a/pkg/podgrouper/podgrouper/plugins/jobset/jobset_grouper.go
+++ b/pkg/podgrouper/podgrouper/plugins/jobset/jobset_grouper.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgroup"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/defaultgrouper"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/minmember"
 )
 
 const (
@@ -113,15 +114,12 @@ func computePodGroupMinSubGroup(jobSet *unstructured.Unstructured, replicatedJob
 	numReplicatedJobs := int32(len(replicatedJobs))
 
 	if override, ok := jobSet.GetAnnotations()[constants.MinMemberOverrideKey]; ok {
-		userSetMinSubGroup, err := strconv.ParseInt(override, 10, 32)
+		userSetMinSubGroup, err := minmember.Parse(override, "JobSet")
 		if err != nil {
-			return 0, fmt.Errorf("invalid %s annotation on JobSet: %w", constants.MinMemberOverrideKey, err)
+			return 0, err
 		}
-		if userSetMinSubGroup < 1 {
-			return 0, fmt.Errorf("invalid %s annotation on JobSet: value %d must be >= 1", constants.MinMemberOverrideKey, userSetMinSubGroup)
-		}
-		if int32(userSetMinSubGroup) < numReplicatedJobs {
-			return int32(userSetMinSubGroup), nil
+		if userSetMinSubGroup < numReplicatedJobs {
+			return userSetMinSubGroup, nil
 		}
 		return numReplicatedJobs, nil
 	}
@@ -218,14 +216,11 @@ func singleReplicaSubGroupMinMember(rj map[string]any) (int32, error) {
 		return parallelism, nil
 	}
 
-	userSetMinMember, err := strconv.ParseInt(singleReplicaUserSetMinMember, 10, 32)
+	userSetMinMember, err := minmember.Parse(singleReplicaUserSetMinMember, "replicatedJob template")
 	if err != nil {
-		return 0, fmt.Errorf("invalid %s annotation on replicatedJob template: %w", constants.MinMemberOverrideKey, err)
+		return 0, err
 	}
-	if userSetMinMember < 1 {
-		return 0, fmt.Errorf("invalid %s annotation on replicatedJob template: value %d must be >= 1", constants.MinMemberOverrideKey, userSetMinMember)
-	}
-	if int32(userSetMinMember) > parallelism {
+	if userSetMinMember > parallelism {
 		log.FromContext(context.Background()).Info(
 			"min-member annotation exceeds parallelism; applying user value",
 			"annotation", constants.MinMemberOverrideKey,
@@ -233,7 +228,7 @@ func singleReplicaSubGroupMinMember(rj map[string]any) (int32, error) {
 			"parallelism", parallelism,
 		)
 	}
-	return int32(userSetMinMember), nil
+	return userSetMinMember, nil
 }
 
 func readReplicatedJobTemplateAnnotation(rj map[string]any, key string) (string, error) {

--- a/pkg/podgrouper/podgrouper/plugins/minmember/min_member.go
+++ b/pkg/podgrouper/podgrouper/plugins/minmember/min_member.go
@@ -1,0 +1,40 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+// Package minmember parses the kai.scheduler/batch-min-member annotation, which lets users override the minimal number
+// of members a podgroup or a subgroup requires. The default applied when the annotation is absent is workload specific
+// and stays with the grouper.
+package minmember
+
+import (
+	"fmt"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
+)
+
+// Parse parses a min-member annotation value set on source, which names the annotated object for error reporting.
+func Parse(value, sourceName string) (int32, error) {
+	minMember, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s annotation on %s: %w", constants.MinMemberOverrideKey, sourceName, err)
+	}
+	if minMember < 1 {
+		return 0, fmt.Errorf("invalid %s annotation on %s: value %d must be >= 1",
+			constants.MinMemberOverrideKey, sourceName, minMember)
+	}
+
+	return int32(minMember), nil
+}
+
+// FromAnnotations returns the min-member override of obj, or fallback when the annotation is absent.
+func FromAnnotations(obj metav1.Object, source string, fallback int32) (int32, error) {
+	value, found := obj.GetAnnotations()[constants.MinMemberOverrideKey]
+	if !found {
+		return fallback, nil
+	}
+
+	return Parse(value, source)
+}

--- a/pkg/podgrouper/podgrouper/plugins/minmember/min_member_test.go
+++ b/pkg/podgrouper/podgrouper/plugins/minmember/min_member_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package minmember
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/podgrouper/podgrouper/plugins/constants"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name          string
+		value         string
+		expectedError bool
+		expected      int32
+	}{
+		{name: "single member", value: "1", expected: 1},
+		{name: "multiple members", value: "12", expected: 12},
+		{name: "zero", value: "0", expectedError: true},
+		{name: "negative", value: "-1", expectedError: true},
+		{name: "not a number", value: "all", expectedError: true},
+		{name: "empty", value: "", expectedError: true},
+		{name: "float", value: "1.5", expectedError: true},
+		{name: "overflows int32", value: "2147483648", expectedError: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			minMember, err := Parse(test.value, "JobSet")
+			if test.expectedError {
+				assert.NotNil(t, err)
+				assert.Contains(t, err.Error(), constants.MinMemberOverrideKey)
+				assert.Contains(t, err.Error(), "JobSet")
+				return
+			}
+			assert.Nil(t, err)
+			assert.Equal(t, test.expected, minMember)
+		})
+	}
+}
+
+func TestFromAnnotations(t *testing.T) {
+	tests := []struct {
+		name          string
+		annotations   map[string]string
+		fallback      int32
+		expectedError bool
+		expected      int32
+	}{
+		{
+			name:        "annotation absent",
+			annotations: map[string]string{"other": "3"},
+			fallback:    5,
+			expected:    5,
+		},
+		{
+			name:        "annotation overrides the fallback",
+			annotations: map[string]string{constants.MinMemberOverrideKey: "3"},
+			fallback:    5,
+			expected:    3,
+		},
+		{
+			name:          "invalid annotation",
+			annotations:   map[string]string{constants.MinMemberOverrideKey: "0"},
+			fallback:      5,
+			expectedError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			obj := &metav1.ObjectMeta{Annotations: test.annotations}
+
+			minMember, err := FromAnnotations(obj, "Deployment", test.fallback)
+			if test.expectedError {
+				assert.NotNil(t, err)
+				return
+			}
+			assert.Nil(t, err)
+			assert.Equal(t, test.expected, minMember)
+		})
+	}
+}

--- a/pkg/podgrouper/podgrouper/podgrouper_test.go
+++ b/pkg/podgrouper/podgrouper/podgrouper_test.go
@@ -121,7 +121,7 @@ func TestNewPodgrouper(t *testing.T) {
 	resources := append(nativeK8sTestResources, testResources...)
 	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(resources...).Build()
 
-	pluginsHub := pluginshub.NewDefaultPluginsHub(client, false, true, false,
+	pluginsHub := pluginshub.NewDefaultPluginsHub(client, false, true, false, false,
 		queueLabelKey, nodePoolLabelKey, "", "")
 	grouper := podgrouper.NewPodgrouper(client, client, pluginsHub)
 
@@ -318,6 +318,7 @@ kind: Pod
 			pluginsHub := pluginshub.NewDefaultPluginsHub(client,
 				tt.podGrouperOptions.searchForLegacyPodGroups,
 				tt.podGrouperOptions.gangScheduleKnative,
+				false,
 				false,
 				queueLabelKey,
 				nodePoolLabelKey,


### PR DESCRIPTION
## Description

By default, for new deployments, use a single podGroup per deployment

## Related Issues

Fixes #2109

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [x] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

<!-- If yes, describe what changes and how to migrate -->

## Additional Notes

<!-- Screenshots, performance/security considerations, reviewer guidance, etc. -->
