### PR TITLE
fix(scheduler): backport PodGroup identity and gang admission floor fixes to v0.17

### DIFF
--- a/.changes/unreleased/fixed-20260822-122521.yaml
+++ b/.changes/unreleased/fixed-20260822-122521.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Respect hierarchical gang floors during allocation and stale-gang eviction

--- a/.changes/unreleased/fixed-20260822-184759.yaml
+++ b/.changes/unreleased/fixed-20260822-184759.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Isolate same-named PodGroups across Kubernetes namespaces

--- a/pkg/scheduler/actions/allocate/allocate.go
+++ b/pkg/scheduler/actions/allocate/allocate.go
@@ -66,7 +66,7 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 			if err == nil && !pipelined && !alreadyAllocated {
 				setLastStartTimestamp(job)
 			}
-			if err == nil && podgroup_info.HasTasksToAllocate(job, true) {
+			if err == nil && podgroup_info.HasTasksToAllocate(job, podgroup_info.RealTaskAllocation) {
 				jobsOrderByQueues.PushJob(job)
 				continue
 			}
@@ -79,13 +79,14 @@ func (alloc *allocateAction) Execute(ssn *framework.Session) {
 func attemptToAllocateJob(ssn *framework.Session, stmt *framework.Statement, job *podgroup_info.PodGroupInfo) (allocated, pipelined bool) {
 	queue := ssn.ClusterInfo.Queues[job.Queue]
 
-	resReq := podgroup_info.GetTasksToAllocateInitResourceVector(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn, true,
+	resReq := podgroup_info.GetTasksToAllocateInitResourceVector(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
+		podgroup_info.RealTaskAllocation,
 		ssn.ClusterInfo.MinNodeGPUMemoryMiB)
 	log.InfraLogger.V(3).Infof("Attempting to allocate job: <%v/%v> of queue <%v>, resources: <%v>",
 		job.Namespace, job.Name, queue.Name, resReq)
 
 	nodes := maps.Values(ssn.ClusterInfo.Nodes)
-	if !common.AllocateJob(ssn, stmt, nodes, job, false) {
+	if !common.AllocateJob(ssn, stmt, nodes, job, podgroup_info.RealTaskAllocation) {
 		log.InfraLogger.V(3).Infof("Could not allocate resources for job: <%v/%v> of queue <%v>",
 			job.Namespace, job.Name, job.Queue)
 		return false, false

--- a/pkg/scheduler/actions/common/action.go
+++ b/pkg/scheduler/actions/common/action.go
@@ -77,6 +77,7 @@ func TryToVirtuallyAllocatePreemptorAndGetVictims(
 	preemptor *podgroup_info.PodGroupInfo,
 	jobsToAllocate *utils.JobsOrderByQueues,
 	preempteeTasks []*pod_info.PodInfo,
+	preemptorAllocationMode podgroup_info.TaskAllocationMode,
 ) (bool, []*pod_info.PodInfo) {
 	preemptorAllocated := false
 	var newVictims []*pod_info.PodInfo
@@ -89,34 +90,42 @@ func TryToVirtuallyAllocatePreemptorAndGetVictims(
 
 	for !jobsToAllocate.IsEmpty() {
 		jobToAllocate := jobsToAllocate.PopNextJob()
-		if _, exits := potentialVictimsMap[jobToAllocate.UID]; !exits && jobToAllocate.UID != preemptor.UID {
+		if _, exists := potentialVictimsMap[jobToAllocate.UID]; !exists && jobToAllocate.UID != preemptor.UID {
 			continue
 		}
+		allocationMode := taskAllocationModeForPipelining(jobToAllocate, preemptor, preemptorAllocationMode)
 
 		resReq := podgroup_info.GetTasksToAllocateInitResourceVector(
-			jobToAllocate, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false, ssn.ClusterInfo.MinNodeGPUMemoryMiB)
+			jobToAllocate, ssn.SubGroupOrderFn, ssn.TaskOrderFn, allocationMode, ssn.ClusterInfo.MinNodeGPUMemoryMiB)
 		log.InfraLogger.V(6).Infof("Trying to pipeline job: <%s/%s>. resources required: %v",
 			jobToAllocate.Namespace, jobToAllocate.Name, resReq)
 
 		if jobToAllocate.UID != preemptor.UID {
-			if !AllocateJob(ssn, stmt, nodes, jobToAllocate, true) {
+			if !AllocateJob(ssn, stmt, nodes, jobToAllocate, allocationMode) {
 				tasksToAllocate := podgroup_info.GetTasksToAllocate(jobToAllocate, ssn.SubGroupOrderFn,
-					ssn.TaskOrderFn, false)
+					ssn.TaskOrderFn, allocationMode)
 				newVictims = append(newVictims, tasksToAllocate...)
 			}
 			continue
 		}
 
-		success := AllocateJob(ssn, stmt, nodes, jobToAllocate, true)
-		if !success {
-			return false, []*pod_info.PodInfo{}
+		if !AllocateJob(ssn, stmt, nodes, jobToAllocate, allocationMode) {
+			return false, nil
 		}
 		preemptorAllocated = true
 	}
 
-	if preemptorAllocated {
-		return true, newVictims
+	if !preemptorAllocated {
+		return false, nil
 	}
+	return true, newVictims
+}
 
-	return false, []*pod_info.PodInfo{}
+func taskAllocationModeForPipelining(
+	jobToAllocate, preemptor *podgroup_info.PodGroupInfo, preemptorAllocationMode podgroup_info.TaskAllocationMode,
+) podgroup_info.TaskAllocationMode {
+	if jobToAllocate.UID == preemptor.UID {
+		return preemptorAllocationMode
+	}
+	return podgroup_info.VictimReallocation
 }

--- a/pkg/scheduler/actions/common/action_test.go
+++ b/pkg/scheduler/actions/common/action_test.go
@@ -1,0 +1,24 @@
+// Copyright 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/podgroup_info"
+)
+
+func TestTaskAllocationModeForPipelining(t *testing.T) {
+	preemptor := podgroup_info.NewPodGroupInfo("preemptor")
+	victim := podgroup_info.NewPodGroupInfo("victim")
+
+	require.Equal(t, podgroup_info.SimulatedTaskAllocation,
+		taskAllocationModeForPipelining(preemptor, preemptor, podgroup_info.SimulatedTaskAllocation))
+	require.Equal(t, podgroup_info.PartialTaskAllocation,
+		taskAllocationModeForPipelining(preemptor, preemptor, podgroup_info.PartialTaskAllocation))
+	require.Equal(t, podgroup_info.VictimReallocation,
+		taskAllocationModeForPipelining(victim, preemptor, podgroup_info.PartialTaskAllocation))
+}

--- a/pkg/scheduler/actions/common/allocate.go
+++ b/pkg/scheduler/actions/common/allocate.go
@@ -18,13 +18,14 @@ import (
 )
 
 func AllocateJob(ssn *framework.Session, stmt *framework.Statement, nodes []*node_info.NodeInfo,
-	job *podgroup_info.PodGroupInfo, isPipelineOnly bool) bool {
+	job *podgroup_info.PodGroupInfo, allocationMode podgroup_info.TaskAllocationMode) bool {
 	ssn.PreJobAllocation(job)
 
-	tasksToAllocate := podgroup_info.GetTasksToAllocate(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn, !isPipelineOnly)
+	tasksToAllocate := podgroup_info.GetTasksToAllocate(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn, allocationMode)
 	if len(tasksToAllocate) == 0 {
 		return false
 	}
+	isPipelineOnly := allocationMode != podgroup_info.RealTaskAllocation
 
 	result := ssn.IsJobOverQueueCapacityFn(job, tasksToAllocate)
 	if !result.IsSchedulable {

--- a/pkg/scheduler/actions/common/solvers/by_pod_solver.go
+++ b/pkg/scheduler/actions/common/solvers/by_pod_solver.go
@@ -164,7 +164,7 @@ func (s *byPodSolver) tryScenarioWithEvictedVictims(ssn *framework.Session, scen
 	jobsToAllocate := common.GetJobsToAllocate(ssn, victimTasks, pendingJob)
 	isSuccessfulAllocations, _ :=
 		common.TryToVirtuallyAllocatePreemptorAndGetVictims(ssn, statement, nodes, pendingJob,
-			jobsToAllocate, victimTasks)
+			jobsToAllocate, victimTasks, podgroup_info.PartialTaskAllocation)
 
 	if !isSuccessfulAllocations {
 		return false, nil

--- a/pkg/scheduler/actions/common/solvers/by_pod_solver_test.go
+++ b/pkg/scheduler/actions/common/solvers/by_pod_solver_test.go
@@ -48,6 +48,7 @@ func newByPodSolverRollbackTestScenario(t *testing.T) (*framework.Session, *scen
 	require.NoError(t, ssn.InitNodeScoringPool())
 	_, victimTasks := addGeneratorTestJob(t, ssn, 1, 20, "team-victim", "node-1")
 	pendingJob := addGeneratorTestPendingJob(t, ssn, 1, 10, "team-pending")
-	pendingTasks := podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
+	pendingTasks := podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
+		podgroup_info.SimulatedTaskAllocation)
 	return ssn, scenario.NewByNodeScenario(ssn, pendingJob, pendingTasks, victimTasks, nil)
 }

--- a/pkg/scheduler/actions/common/solvers/job_solver.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver.go
@@ -98,7 +98,8 @@ func (s *JobSolver) SolveWithResult(
 
 	originalNumActiveTasks := pendingJob.GetNumActiveUsedTasks()
 
-	tasksToAllocate := podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
+	tasksToAllocate := podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
+		podgroup_info.SimulatedTaskAllocation)
 	n := len(tasksToAllocate)
 	if n == 0 {
 		searchResult := terminalSearchResult(SearchResultGeneratorsExhausted, false)

--- a/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
+++ b/pkg/scheduler/actions/common/solvers/job_solver_result_test.go
@@ -206,7 +206,8 @@ func TestSolveWithResultRecordsUnsolvedScenarioDurationAfterSimulation(t *testin
 	ssn.ClusterInfo.Nodes = map[string]*node_info.NodeInfo{"node-1": {}}
 	scenarioToSolve := scenario.NewByNodeScenario(
 		ssn, pendingJob,
-		podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false),
+		podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
+			podgroup_info.SimulatedTaskAllocation),
 		nil, nil,
 	)
 	ssn.AddScenarioGenerator(generatorName, portfolioTestFactory(&portfolioTestGenerator{
@@ -249,7 +250,8 @@ func TestSolveWithResultRunsCompletePartialSearchForOneGeneratorBeforeNext(t *te
 		solveCtx := ctx.(*SolveContext)
 		factoryCalls = append(factoryCalls, fmt.Sprintf("second:%d", solveCtx.ProbeK))
 		pendingTasks := podgroup_info.GetTasksToAllocate(
-			solveCtx.PartialPendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false,
+			solveCtx.PartialPendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
+			podgroup_info.SimulatedTaskAllocation,
 		)
 		sn := scenario.NewByNodeScenario(
 			ssn, solveCtx.PartialPendingJob, pendingTasks,
@@ -291,7 +293,8 @@ func TestSolveWithResultStillSolvesWhenGeneratorRepeatsScenarios(t *testing.T) {
 	ssn.AddScenarioGenerator(generatorName, func(ctx framework.ScenarioGeneratorContext) framework.ScenarioGenerator {
 		solveCtx := ctx.(*SolveContext)
 		pendingTasks := podgroup_info.GetTasksToAllocate(
-			solveCtx.PartialPendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false,
+			solveCtx.PartialPendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
+			podgroup_info.SimulatedTaskAllocation,
 		)
 		failing := scenario.NewByNodeScenario(
 			ssn, solveCtx.PartialPendingJob, pendingTasks, nil, solveCtx.RecordedVictimsJobs,

--- a/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
+++ b/pkg/scheduler/actions/common/solvers/pod_scenario_builder.go
@@ -48,7 +48,8 @@ func NewPodAccumulatedScenarioBuilder(
 
 	var scenario *solverscenario.ByNodeScenario = nil
 	recordedVictimsTasks := make(map[common_info.PodID]*pod_info.PodInfo)
-	tasksToAllocate := podgroup_info.GetTasksToAllocate(pendingJob, session.SubGroupOrderFn, session.TaskOrderFn, false)
+	tasksToAllocate := podgroup_info.GetTasksToAllocate(pendingJob, session.SubGroupOrderFn, session.TaskOrderFn,
+		podgroup_info.PartialTaskAllocation)
 	if len(tasksToAllocate) != 0 {
 		scenario = solverscenario.NewByNodeScenario(session, pendingJob, tasksToAllocate, nil, recordedVictimsJobs)
 		for _, job := range recordedVictimsJobs {

--- a/pkg/scheduler/actions/common/solvers/scenario_fingerprint_test.go
+++ b/pkg/scheduler/actions/common/solvers/scenario_fingerprint_test.go
@@ -205,7 +205,8 @@ func newDedupCacheTestSession(t *testing.T) (*framework.Session, *podgroup_info.
 }
 
 func dedupCacheTestPendingTasks(ssn *framework.Session, pendingJob *podgroup_info.PodGroupInfo) []*pod_info.PodInfo {
-	return podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
+	return podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
+		podgroup_info.SimulatedTaskAllocation)
 }
 
 func reversedTasks(tasks []*pod_info.PodInfo) []*pod_info.PodInfo {

--- a/pkg/scheduler/actions/common/solvers/scenario_portfolio_test.go
+++ b/pkg/scheduler/actions/common/solvers/scenario_portfolio_test.go
@@ -185,7 +185,8 @@ func newPortfolioTestByNodeScenario(
 ) *scenario.ByNodeScenario {
 	t.Helper()
 
-	pendingTasks := podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
+	pendingTasks := podgroup_info.GetTasksToAllocate(pendingJob, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
+		podgroup_info.SimulatedTaskAllocation)
 	return scenario.NewByNodeScenario(ssn, pendingJob, pendingTasks, nil, nil)
 }
 

--- a/pkg/scheduler/actions/consolidation/consolidation.go
+++ b/pkg/scheduler/actions/consolidation/consolidation.go
@@ -71,7 +71,8 @@ func (alloc *consolidationAction) Execute(ssn *framework.Session) {
 				continue
 			}
 		}
-		tasks := podgroup_info.GetTasksToAllocate(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
+		tasks := podgroup_info.GetTasksToAllocate(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
+			podgroup_info.SimulatedTaskAllocation)
 		if task, failure := common.VictimInvariantPrePredicateFailureForTasks(ssn, tasks); failure != nil {
 			common.RecordVictimInvariantPrePredicateFailure(job, task, failure)
 			continue
@@ -96,11 +97,11 @@ func attemptToConsolidateForPreemptor(
 	ssn *framework.Session, job *podgroup_info.PodGroupInfo, actionBudget *solvers.ActionSearchBudget,
 ) (bool, *framework.Statement, *solvers.SearchResult) {
 	resReq := podgroup_info.GetTasksToAllocateInitResourceVector(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
-		false, ssn.ClusterInfo.MinNodeGPUMemoryMiB)
+		podgroup_info.SimulatedTaskAllocation, ssn.ClusterInfo.MinNodeGPUMemoryMiB)
 	log.InfraLogger.V(3).Infof(
 		"Attempting to consolidate running jobs in order to make room for job: <%s/%s>, resources: <%v>",
 		job.Namespace, job.Name, resReq)
-	if !utils.IsEnoughGPUsAllocatableForJob(job, ssn, false) {
+	if !utils.IsEnoughGPUsAllocatableForJob(job, ssn, podgroup_info.SimulatedTaskAllocation) {
 		log.InfraLogger.V(3).Infof(
 			"Can't consolidate for job: <%v/%v>, not enough allocatable GPUs in the cluster",
 			job.Namespace, job.Name)

--- a/pkg/scheduler/actions/preempt/preempt.go
+++ b/pkg/scheduler/actions/preempt/preempt.go
@@ -83,7 +83,8 @@ func (alloc *preemptAction) Execute(ssn *framework.Session) {
 				continue
 			}
 		}
-		tasks := podgroup_info.GetTasksToAllocate(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
+		tasks := podgroup_info.GetTasksToAllocate(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
+			podgroup_info.SimulatedTaskAllocation)
 		if task, failure := common.VictimInvariantPrePredicateFailureForTasks(ssn, tasks); failure != nil {
 			common.RecordVictimInvariantPrePredicateFailure(job, task, failure)
 			continue
@@ -114,12 +115,13 @@ func attemptToPreemptForPreemptor(
 	ssn *framework.Session, preemptor *podgroup_info.PodGroupInfo, actionBudget *solvers.ActionSearchBudget,
 ) (bool, *framework.Statement, []string, *solvers.SearchResult) {
 	resReq := podgroup_info.GetTasksToAllocateInitResourceVector(preemptor, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
-		false, ssn.ClusterInfo.MinNodeGPUMemoryMiB)
+		podgroup_info.SimulatedTaskAllocation, ssn.ClusterInfo.MinNodeGPUMemoryMiB)
 	log.InfraLogger.V(3).Infof(
 		"Attempting to preempt for job: <%v/%v>, priority: <%v>, queue: <%v>, resources: <%v>",
 		preemptor.Namespace, preemptor.Name, preemptor.Priority, preemptor.Queue, resReq)
 
-	preemptorTasks := podgroup_info.GetTasksToAllocate(preemptor, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
+	preemptorTasks := podgroup_info.GetTasksToAllocate(preemptor, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
+		podgroup_info.SimulatedTaskAllocation)
 	if result := ssn.IsNonPreemptibleJobOverQueueQuotaFn(preemptor, preemptorTasks); !result.IsSchedulable {
 		log.InfraLogger.V(3).Infof("Job <%v/%v> would have placed the queue resources over quota",
 			preemptor.Namespace, preemptor.Name)

--- a/pkg/scheduler/actions/reclaim/reclaim.go
+++ b/pkg/scheduler/actions/reclaim/reclaim.go
@@ -86,7 +86,8 @@ func (ra *reclaimAction) Execute(ssn *framework.Session) {
 				continue
 			}
 		}
-		tasks := podgroup_info.GetTasksToAllocate(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn, false)
+		tasks := podgroup_info.GetTasksToAllocate(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
+			podgroup_info.SimulatedTaskAllocation)
 		if task, failure := common.VictimInvariantPrePredicateFailureForTasks(ssn, tasks); failure != nil {
 			common.RecordVictimInvariantPrePredicateFailure(job, task, failure)
 			continue
@@ -117,7 +118,7 @@ func (ra *reclaimAction) attemptToReclaimForSpecificJob(
 ) (bool, *framework.Statement, []string, *solvers.SearchResult) {
 	queue := ssn.ClusterInfo.Queues[reclaimer.Queue]
 	resReq := podgroup_info.GetTasksToAllocateInitResourceVector(reclaimer, ssn.SubGroupOrderFn, ssn.TaskOrderFn,
-		false, ssn.ClusterInfo.MinNodeGPUMemoryMiB)
+		podgroup_info.SimulatedTaskAllocation, ssn.ClusterInfo.MinNodeGPUMemoryMiB)
 	log.InfraLogger.V(3).Infof("Attempting to reclaim for job: <%v/%v> of queue <%v>, resources: <%v>",
 		reclaimer.Namespace, reclaimer.Name, queue.Name, resReq)
 

--- a/pkg/scheduler/actions/utils/action.go
+++ b/pkg/scheduler/actions/utils/action.go
@@ -184,11 +184,13 @@ func GetAllPendingJobs(ssn *framework.Session) map[common_info.PodGroupID]*podgr
 	return pendingJobs
 }
 
-func IsEnoughGPUsAllocatableForJob(job *podgroup_info.PodGroupInfo, ssn *framework.Session, isRealAllocation bool) bool {
+func IsEnoughGPUsAllocatableForJob(
+	job *podgroup_info.PodGroupInfo, ssn *framework.Session, allocationMode podgroup_info.TaskAllocationMode,
+) bool {
 	sumOfAllAllocatableGPUs, sumOfAllAllocatableGPUsMemory := getSumOfAvailableGPUs(ssn)
 	requestedGPUs, requestedGpuMemory := podgroup_info.GetTasksToAllocateRequestedGPUs(job, ssn.SubGroupOrderFn,
-		ssn.TaskOrderFn, isRealAllocation)
-	resReq := podgroup_info.GetTasksToAllocateInitResourceVector(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn, isRealAllocation,
+		ssn.TaskOrderFn, allocationMode)
+	resReq := podgroup_info.GetTasksToAllocateInitResourceVector(job, ssn.SubGroupOrderFn, ssn.TaskOrderFn, allocationMode,
 		ssn.ClusterInfo.MinNodeGPUMemoryMiB)
 	log.InfraLogger.V(7).Infof(
 		"Task: <%v/%v> resources requires: <%v>, sumOfAllAllocatableGPUs: <%v, %v mb>",

--- a/pkg/scheduler/api/common_info/common.go
+++ b/pkg/scheduler/api/common_info/common.go
@@ -9,6 +9,10 @@ type PodID types.UID
 
 type PodGroupID types.UID
 
+func NewPodGroupID(namespace, name string) PodGroupID {
+	return PodGroupID(NewObjectKey(namespace, name))
+}
+
 type QueueID types.UID
 
 type StorageClassID types.UID

--- a/pkg/scheduler/api/podgroup_info/allocation_info.go
+++ b/pkg/scheduler/api/podgroup_info/allocation_info.go
@@ -16,9 +16,50 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/scheduler_util"
 )
 
-func HasTasksToAllocate(podGroupInfo *PodGroupInfo, isRealAllocation bool) bool {
+// TaskAllocationMode identifies why tasks are being selected for allocation.
+type TaskAllocationMode int
+
+type taskAllocationCacheMode int
+
+const (
+	// RealTaskAllocation selects pending tasks for binding in the current scheduling cycle.
+	RealTaskAllocation TaskAllocationMode = iota
+	// SimulatedTaskAllocation selects pending tasks while evaluating a scheduling scenario.
+	SimulatedTaskAllocation
+	// PartialTaskAllocation selects partial task sets for internal search and resource accounting.
+	PartialTaskAllocation
+	// VictimReallocation selects tasks from a preempted job while restoring its remaining allocation.
+	VictimReallocation
+)
+
+const (
+	realTaskAllocationCache taskAllocationCacheMode = iota
+	simulatedAdmissionCache
+	partialTaskAllocationCache
+)
+
+func (mode TaskAllocationMode) isRealAllocation() bool {
+	return mode == RealTaskAllocation
+}
+
+func (mode TaskAllocationMode) enforceGangAdmission() bool {
+	return mode == RealTaskAllocation || mode == SimulatedTaskAllocation
+}
+
+func (mode TaskAllocationMode) cacheMode() taskAllocationCacheMode {
+	switch mode {
+	case RealTaskAllocation:
+		return realTaskAllocationCache
+	case SimulatedTaskAllocation:
+		return simulatedAdmissionCache
+	default:
+		return partialTaskAllocationCache
+	}
+}
+
+func HasTasksToAllocate(podGroupInfo *PodGroupInfo, mode TaskAllocationMode) bool {
 	for _, task := range podGroupInfo.GetAllPodsMap() {
-		if task.ShouldAllocate(isRealAllocation) {
+		if task.ShouldAllocate(mode.isRealAllocation()) {
 			return true
 		}
 	}
@@ -30,29 +71,33 @@ func HasTasksToAllocate(podGroupInfo *PodGroupInfo, isRealAllocation bool) bool 
 // For satisfied subgroups, collect tasks only from one direct child (a single subgroup for a minSubgroup or a single pod for a minAvailable).
 func GetTasksToAllocate(
 	podGroupInfo *PodGroupInfo, subGroupOrderFn common_info.LessFn, taskOrderFn common_info.LessFn,
-	isRealAllocation bool,
+	mode TaskAllocationMode,
 ) []*pod_info.PodInfo {
-	if podGroupInfo.tasksToAllocate != nil {
-		return podGroupInfo.tasksToAllocate
+	cacheMode := mode.cacheMode()
+	if tasks, ok := podGroupInfo.tasksToAllocateByMode[cacheMode]; ok {
+		return tasks
 	}
 
-	root := podGroupInfo.RootSubGroupSet
-	if root == nil {
-		root = subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
-		for _, ps := range podGroupInfo.PodSets {
-			root.AddPodSet(ps)
-		}
+	if podGroupInfo.RootSubGroupSet == nil {
+		return nil
 	}
-	tasks := collectTasksFromSubGroupSet(root, subGroupOrderFn, taskOrderFn, isRealAllocation)
-	podGroupInfo.tasksToAllocate = tasks
+	tasks := collectTasksFromSubGroupSet(podGroupInfo.RootSubGroupSet, subGroupOrderFn, taskOrderFn, mode)
+	if podGroupInfo.tasksToAllocateByMode == nil {
+		podGroupInfo.tasksToAllocateByMode = make(map[taskAllocationCacheMode][]*pod_info.PodInfo)
+	}
+	podGroupInfo.tasksToAllocateByMode[cacheMode] = tasks
 	return tasks
 }
 
 // collectTasksFromSubGroupSet walks the SubGroupSet tree and collects tasks to allocate.
 func collectTasksFromSubGroupSet(
 	sgs *subgroup_info.SubGroupSet, subGroupOrderFn common_info.LessFn, taskOrderFn common_info.LessFn,
-	isRealAllocation bool,
+	mode TaskAllocationMode,
 ) []*pod_info.PodInfo {
+	if mode.enforceGangAdmission() && !sgs.IsReadyForScheduling() {
+		return nil
+	}
+
 	K := sgs.GetMinMembersToSatisfy()
 	children := sgs.GetMembers()
 	sort.Slice(children, func(i, j int) bool {
@@ -60,17 +105,22 @@ func collectTasksFromSubGroupSet(
 	})
 
 	if !sgs.IsMinRequirementSatisfied() {
-		// Get tasks from K most prioritized children, so sgs can satisfy its min requirement.
+		membersToCollect := K - sgs.GetNumActiveAllocatedDirectSubGroups()
 		var tasks []*pod_info.PodInfo
-		for i := 0; i < K && i < len(children); i++ {
-			tasks = append(tasks, collectFromChildInGangPhase(children[i], subGroupOrderFn, taskOrderFn, isRealAllocation)...)
+		for i := 0; i < len(children) && membersToCollect > 0; i++ {
+			childTasks := collectFromChildInGangPhase(children[i], subGroupOrderFn, taskOrderFn, mode)
+			if len(childTasks) == 0 {
+				continue
+			}
+			tasks = append(tasks, childTasks...)
+			membersToCollect--
 		}
 		return tasks
 	}
 
 	// Elastic phase: get the most prioritized unsatisfied child, and allocate it
 	for i := 0; i < len(children); i++ {
-		childTasks := collectFromChildSubgroup(children[i], subGroupOrderFn, taskOrderFn, isRealAllocation)
+		childTasks := collectFromChildSubgroup(children[i], subGroupOrderFn, taskOrderFn, mode)
 		if len(childTasks) > 0 {
 			return childTasks
 		}
@@ -83,52 +133,55 @@ func collectTasksFromSubGroupSet(
 // is already met and collecting elastic tasks from them would over-count resource needs.
 func collectFromChildInGangPhase(
 	child subgroup_info.SubGroupMember, subGroupOrderFn common_info.LessFn, taskOrderFn common_info.LessFn,
-	isRealAllocation bool,
+	mode TaskAllocationMode,
 ) []*pod_info.PodInfo {
 	switch c := child.(type) {
 	case *subgroup_info.SubGroupSet:
 		if c.IsMinRequirementSatisfied() {
 			return nil // already satisfied; skip in parent gang phase
 		}
-		return collectTasksFromSubGroupSet(c, subGroupOrderFn, taskOrderFn, isRealAllocation)
+		return collectTasksFromSubGroupSet(c, subGroupOrderFn, taskOrderFn, mode)
 	case *subgroup_info.PodSet:
 		if c.GetNumActiveAllocatedTasks() >= int(c.GetMinAvailable()) {
 			return nil // already satisfied; skip in parent gang phase
 		}
-		return collectTasksFromPodSet(c, taskOrderFn, isRealAllocation)
+		return collectTasksFromPodSet(c, taskOrderFn, mode)
 	}
 	return nil
 }
 
 func collectFromChildSubgroup(
 	child subgroup_info.SubGroupMember, subGroupOrderFn common_info.LessFn, taskOrderFn common_info.LessFn,
-	isRealAllocation bool,
+	mode TaskAllocationMode,
 ) []*pod_info.PodInfo {
 	switch c := child.(type) {
 	case *subgroup_info.SubGroupSet:
-		return collectTasksFromSubGroupSet(c, subGroupOrderFn, taskOrderFn, isRealAllocation)
+		return collectTasksFromSubGroupSet(c, subGroupOrderFn, taskOrderFn, mode)
 	case *subgroup_info.PodSet:
-		return collectTasksFromPodSet(c, taskOrderFn, isRealAllocation)
+		return collectTasksFromPodSet(c, taskOrderFn, mode)
 	}
 	return nil
 }
 
-func collectTasksFromPodSet(ps *subgroup_info.PodSet, taskOrderFn common_info.LessFn, isRealAllocation bool) []*pod_info.PodInfo {
-	taskPriorityQueue := getTasksPriorityQueue(ps, taskOrderFn, isRealAllocation)
+func collectTasksFromPodSet(ps *subgroup_info.PodSet, taskOrderFn common_info.LessFn, mode TaskAllocationMode) []*pod_info.PodInfo {
+	taskPriorityQueue := getTasksPriorityQueue(ps, taskOrderFn, mode.isRealAllocation())
 	if taskPriorityQueue.Empty() {
 		return nil
 	}
-	maxNumOfTasksToAllocate := getNumTasksToAllocate(ps, isRealAllocation)
-	return getTasksFromQueue(taskPriorityQueue, maxNumOfTasksToAllocate)
+	numTasksToAllocate := getNumTasksToAllocate(ps, mode.isRealAllocation())
+	if mode.enforceGangAdmission() && ps.GetNumActiveAllocatedTasks() < int(ps.GetMinAvailable()) && taskPriorityQueue.Len() < numTasksToAllocate {
+		return nil
+	}
+	return getTasksFromQueue(taskPriorityQueue, numTasksToAllocate)
 }
 
 func GetTasksToAllocateRequestedGPUs(
 	podGroupInfo *PodGroupInfo, subGroupOrderFn common_info.LessFn, taskOrderFn common_info.LessFn,
-	isRealAllocation bool,
+	mode TaskAllocationMode,
 ) (float64, int64) {
 	tasksTotalRequestedGPUs := float64(0)
 	tasksTotalRequestedGpuMemory := int64(0)
-	for _, task := range GetTasksToAllocate(podGroupInfo, subGroupOrderFn, taskOrderFn, isRealAllocation) {
+	for _, task := range GetTasksToAllocate(podGroupInfo, subGroupOrderFn, taskOrderFn, mode) {
 		tasksTotalRequestedGPUs += task.GpuRequirement.GPUs()
 		tasksTotalRequestedGpuMemory += task.GpuRequirement.GpuMemory()
 
@@ -163,19 +216,20 @@ func GetTasksToAllocateRequestedGPUs(
 // divisor (e.g. capacity_policy's max) must compute its own conversion, not route through here.
 func GetTasksToAllocateInitResourceVector(
 	podGroupInfo *PodGroupInfo, subGroupOrderFn common_info.LessFn, taskOrderFn common_info.LessFn,
-	isRealAllocation bool, minNodeGPUMemory *int64,
+	mode TaskAllocationMode, minNodeGPUMemory *int64,
 ) resource_info.ResourceVector {
 	if podGroupInfo == nil {
 		return nil
 	}
-	if podGroupInfo.tasksToAllocateInitResourceVector != nil {
-		return podGroupInfo.tasksToAllocateInitResourceVector
+	cacheMode := mode.cacheMode()
+	if result, ok := podGroupInfo.tasksToAllocateInitResourceVectorByMode[cacheMode]; ok {
+		return result
 	}
 
 	result := resource_info.NewResourceVector(podGroupInfo.VectorMap)
 	gpuIdx := resource_info.GPUIndex
-	for _, task := range GetTasksToAllocate(podGroupInfo, subGroupOrderFn, taskOrderFn, isRealAllocation) {
-		if task.ShouldAllocate(isRealAllocation) {
+	for _, task := range GetTasksToAllocate(podGroupInfo, subGroupOrderFn, taskOrderFn, mode) {
+		if task.ShouldAllocate(mode.isRealAllocation()) {
 			result.Add(task.ResReqVector)
 			if task.IsGpuMemoryRequest() && minNodeGPUMemory != nil {
 				result.Set(gpuIdx, result.Get(gpuIdx)+task.GpuRequirement.GpuMemoryAsGpuFraction(*minNodeGPUMemory))
@@ -183,7 +237,10 @@ func GetTasksToAllocateInitResourceVector(
 		}
 	}
 
-	podGroupInfo.tasksToAllocateInitResourceVector = result
+	if podGroupInfo.tasksToAllocateInitResourceVectorByMode == nil {
+		podGroupInfo.tasksToAllocateInitResourceVectorByMode = make(map[taskAllocationCacheMode]resource_info.ResourceVector)
+	}
+	podGroupInfo.tasksToAllocateInitResourceVectorByMode[cacheMode] = result
 	return result
 }
 

--- a/pkg/scheduler/api/podgroup_info/allocation_info_test.go
+++ b/pkg/scheduler/api/podgroup_info/allocation_info_test.go
@@ -9,6 +9,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
@@ -43,18 +44,18 @@ func subGroupOrderFn(l, r interface{}) bool {
 
 func Test_HasTasksToAllocate(t *testing.T) {
 	pg := NewPodGroupInfo("pg1")
-	if HasTasksToAllocate(pg, true) {
+	if HasTasksToAllocate(pg, RealTaskAllocation) {
 		t.Error("expected false with zero tasks")
 	}
 	// Add one pending that ShouldAllocate
 	task := simpleTask("p1", "", pod_status.Pending)
 	pg.AddTaskInfo(task)
-	if !HasTasksToAllocate(pg, true) {
+	if !HasTasksToAllocate(pg, RealTaskAllocation) {
 		t.Error("expected true with allocatable task")
 	}
 	// Now set the status so ShouldAllocate returns false
 	task.Status = pod_status.Succeeded
-	if HasTasksToAllocate(pg, true) {
+	if HasTasksToAllocate(pg, RealTaskAllocation) {
 		t.Error("expected false with non-allocatable status")
 	}
 }
@@ -90,6 +91,57 @@ func Test_GetTasksToAllocate(t *testing.T) {
 			minAvailMap:  map[string]int32{"subGroup2": 2},
 			wantTasks:    []string{"task1", "task2"},
 			wantNumTasks: 2,
+		},
+		{
+			name: "pending tasks below minAvailable",
+			subGroupTasks: map[string][]*pod_info.PodInfo{
+				"subGroup2": {
+					simpleTask("task1", "subGroup2", pod_status.Pending),
+				},
+			},
+			minAvailMap:  map[string]int32{"subGroup2": 2},
+			wantTasks:    []string{},
+			wantNumTasks: 0,
+		},
+		{
+			name: "three pending tasks below minAvailable four",
+			subGroupTasks: map[string][]*pod_info.PodInfo{
+				"subGroup4": {
+					simpleTask("task1", "subGroup4", pod_status.Pending),
+					simpleTask("task2", "subGroup4", pod_status.Pending),
+					simpleTask("task3", "subGroup4", pod_status.Pending),
+				},
+			},
+			minAvailMap:  map[string]int32{"subGroup4": 4},
+			wantTasks:    []string{},
+			wantNumTasks: 0,
+		},
+		{
+			name: "pending tasks below remaining minAvailable",
+			subGroupTasks: map[string][]*pod_info.PodInfo{
+				"subGroup4": {
+					simpleTask("task1", "subGroup4", pod_status.Allocated),
+					simpleTask("task2", "subGroup4", pod_status.Allocated),
+					simpleTask("task3", "subGroup4", pod_status.Pending),
+				},
+			},
+			minAvailMap:  map[string]int32{"subGroup4": 4},
+			wantTasks:    []string{},
+			wantNumTasks: 0,
+		},
+		{
+			name: "one pending task completes minAvailable",
+			subGroupTasks: map[string][]*pod_info.PodInfo{
+				"subGroup4": {
+					simpleTask("task1", "subGroup4", pod_status.Running),
+					simpleTask("task2", "subGroup4", pod_status.Running),
+					simpleTask("task3", "subGroup4", pod_status.Running),
+					simpleTask("task4", "subGroup4", pod_status.Pending),
+				},
+			},
+			minAvailMap:  map[string]int32{"subGroup4": 4},
+			wantTasks:    []string{"task4"},
+			wantNumTasks: 1,
 		},
 		{
 			name: "one allocated and one pending",
@@ -207,7 +259,7 @@ func Test_GetTasksToAllocate(t *testing.T) {
 					pg.AddTaskInfo(pod)
 				}
 			}
-			gotTasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, true)
+			gotTasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, RealTaskAllocation)
 			if len(gotTasks) != tt.wantNumTasks {
 				t.Errorf("expected %d tasks to allocate, got %d", tt.wantNumTasks, len(gotTasks))
 			}
@@ -217,6 +269,153 @@ func Test_GetTasksToAllocate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func Test_GetTasksToAllocate_SkipsUnreadyChildInGangPhase(t *testing.T) {
+	pg := NewPodGroupInfo("pg")
+	root := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
+	minSubGroup := int32(1)
+	root.SetMinSubGroup(&minSubGroup)
+	pg.RootSubGroupSet = root
+	pg.PodSets = make(map[string]*subgroup_info.PodSet)
+
+	unreadyPodSet := subgroup_info.NewPodSet("a", 2, nil)
+	readyPodSet := subgroup_info.NewPodSet("b", 1, nil)
+	root.AddPodSet(unreadyPodSet)
+	root.AddPodSet(readyPodSet)
+	pg.PodSets[unreadyPodSet.GetName()] = unreadyPodSet
+	pg.PodSets[readyPodSet.GetName()] = readyPodSet
+	pg.AddTaskInfo(simpleTask("task-a", "a", pod_status.Pending))
+	pg.AddTaskInfo(simpleTask("task-b", "b", pod_status.Pending))
+
+	tasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, RealTaskAllocation)
+	if len(tasks) != 1 || tasks[0].Pod.Name != "task-b" {
+		t.Fatalf("GetTasksToAllocate() = %v, want task-b", tasks)
+	}
+}
+
+func Test_GetTasksToAllocate_VictimReallocationBelowMinAvailable(t *testing.T) {
+	pg := NewPodGroupInfo("pg")
+	pg.GetAllPodSets()[DefaultSubGroup].SetMinAvailable(4)
+	for i := 1; i <= 3; i++ {
+		task := simpleTask(fmt.Sprintf("task-%d", i), "", pod_status.Releasing)
+		task.IsVirtualStatus = true
+		pg.AddTaskInfo(task)
+	}
+
+	tasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, VictimReallocation)
+	if len(tasks) != 3 {
+		t.Fatalf("GetTasksToAllocate() returned %d tasks, want 3", len(tasks))
+	}
+}
+
+func Test_GetTasksToAllocate_PartialModeBelowMinAvailable(t *testing.T) {
+	pg := NewPodGroupInfo("pg")
+	pg.GetAllPodSets()[DefaultSubGroup].SetMinAvailable(2)
+	pg.AddTaskInfo(simpleTask("task-1", "", pod_status.Pending))
+
+	tasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, PartialTaskAllocation)
+	if len(tasks) != 1 {
+		t.Fatalf("GetTasksToAllocate() returned %d probe tasks, want 1", len(tasks))
+	}
+}
+
+func Test_GetTasksToAllocate_SimulatedPendingAdmissionRespectsMinAvailable(t *testing.T) {
+	pg := NewPodGroupInfo("pg")
+	pg.GetAllPodSets()[DefaultSubGroup].SetMinAvailable(2)
+	pg.AddTaskInfo(simpleTask("task-1", "", pod_status.Pending))
+
+	tasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, SimulatedTaskAllocation)
+	if len(tasks) != 0 {
+		t.Fatalf("GetTasksToAllocate() returned %d pending tasks, want 0", len(tasks))
+	}
+}
+
+func Test_GetTasksToAllocate_SimulatedAdmissionSkipsUnreadyChild(t *testing.T) {
+	pg := NewPodGroupInfo("pg")
+	root := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
+	root.SetMinSubGroup(ptr.To(int32(1)))
+	pg.RootSubGroupSet = root
+	pg.PodSets = make(map[string]*subgroup_info.PodSet)
+
+	unreadyPodSet := subgroup_info.NewPodSet("a", 2, nil)
+	readyPodSet := subgroup_info.NewPodSet("b", 1, nil)
+	root.AddPodSet(unreadyPodSet)
+	root.AddPodSet(readyPodSet)
+	pg.PodSets = root.GetDescendantPodSets()
+	pg.AddTaskInfo(simpleTask("task-a", "a", pod_status.Pending))
+	pg.AddTaskInfo(simpleTask("task-b", "b", pod_status.Pending))
+
+	tasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, SimulatedTaskAllocation)
+	if len(tasks) != 1 || tasks[0].Name != "task-b" {
+		t.Fatalf("GetTasksToAllocate() = %v, want task-b", tasks)
+	}
+}
+
+func Test_GetTasksToAllocate_CachesByAdmissionSemantics(t *testing.T) {
+	pg := NewPodGroupInfo("pg")
+	pg.GetAllPodSets()[DefaultSubGroup].SetMinAvailable(4)
+	for i := 1; i <= 3; i++ {
+		pg.AddTaskInfo(simpleTask(fmt.Sprintf("task-%d", i), "", pod_status.Pending))
+	}
+
+	partialTasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, PartialTaskAllocation)
+	if len(partialTasks) != 3 {
+		t.Fatalf("partial GetTasksToAllocate() returned %d tasks, want 3", len(partialTasks))
+	}
+
+	realTasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, RealTaskAllocation)
+	if len(realTasks) != 0 {
+		t.Fatalf("real GetTasksToAllocate() returned %d tasks after partial lookup, want 0", len(realTasks))
+	}
+
+	simulatedTasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, SimulatedTaskAllocation)
+	if len(simulatedTasks) != 0 {
+		t.Fatalf("simulated GetTasksToAllocate() returned %d tasks after partial lookup, want 0", len(simulatedTasks))
+	}
+
+	pg = NewPodGroupInfo("pg-reverse")
+	pg.GetAllPodSets()[DefaultSubGroup].SetMinAvailable(1)
+	releasingTask := simpleTask("a-releasing", "", pod_status.Releasing)
+	releasingTask.IsVirtualStatus = true
+	pg.AddTaskInfo(releasingTask)
+	pg.AddTaskInfo(simpleTask("b-pending", "", pod_status.Pending))
+
+	realTasks = GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, RealTaskAllocation)
+	if len(realTasks) != 1 || realTasks[0].Name != "b-pending" {
+		t.Fatalf("real GetTasksToAllocate() = %v, want b-pending", realTasks)
+	}
+
+	victimTasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, VictimReallocation)
+	if len(victimTasks) != 1 || victimTasks[0].Name != "a-releasing" {
+		t.Fatalf("victim GetTasksToAllocate() after real lookup = %v, want a-releasing", victimTasks)
+	}
+}
+
+func Test_GetTasksToAllocateInitResourceVector_CachesByAdmissionSemantics(t *testing.T) {
+	vectorMap := resource_info.NewResourceVectorMap()
+	pg := NewPodGroupInfoWithVectorMap("pg", vectorMap)
+	pg.GetAllPodSets()[DefaultSubGroup].SetMinAvailable(2)
+
+	task := simpleTask("task-1", "", pod_status.Pending)
+	task.ResReqVector = resource_info.NewResourceRequirements(0, 1000, 0).ToVector(vectorMap)
+	task.VectorMap = vectorMap
+	pg.AddTaskInfo(task)
+
+	partialVector := GetTasksToAllocateInitResourceVector(pg, subGroupOrderFn, tasksOrderFn, PartialTaskAllocation, nil)
+	if got := partialVector.Get(resource_info.CPUIndex); got != 1000 {
+		t.Fatalf("partial resource vector CPU = %v, want 1000", got)
+	}
+
+	realVector := GetTasksToAllocateInitResourceVector(pg, subGroupOrderFn, tasksOrderFn, RealTaskAllocation, nil)
+	if got := realVector.Get(resource_info.CPUIndex); got != 0 {
+		t.Fatalf("real resource vector CPU after partial lookup = %v, want 0", got)
+	}
+
+	simulatedVector := GetTasksToAllocateInitResourceVector(pg, subGroupOrderFn, tasksOrderFn, SimulatedTaskAllocation, nil)
+	if got := simulatedVector.Get(resource_info.CPUIndex); got != 0 {
+		t.Fatalf("simulated resource vector CPU after partial lookup = %v, want 0", got)
 	}
 }
 
@@ -285,7 +484,7 @@ func Test_GetTasksToAllocate_MinSubGroupZero(t *testing.T) {
 					pg.AddTaskInfo(pod)
 				}
 			}
-			gotTasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, true)
+			gotTasks := GetTasksToAllocate(pg, subGroupOrderFn, tasksOrderFn, RealTaskAllocation)
 			if len(gotTasks) != tt.wantNumTasks {
 				t.Errorf("GetTasksToAllocate len = %d, want %d", len(gotTasks), tt.wantNumTasks)
 			}
@@ -300,7 +499,7 @@ func Test_GetTasksToAllocateRequestedGPUs(t *testing.T) {
 	// manually set up a fake GpuRequirement that returns 2 for GPUs
 	task.GpuRequirement = *resource_info.NewGpuResourceRequirementWithGpus(2, 0)
 	pg.AddTaskInfo(task)
-	gpus, _ := GetTasksToAllocateRequestedGPUs(pg, subGroupOrderFn, tasksOrderFn, true)
+	gpus, _ := GetTasksToAllocateRequestedGPUs(pg, subGroupOrderFn, tasksOrderFn, RealTaskAllocation)
 	if gpus != 2 {
 		t.Errorf("expected gpus=2, got %v", gpus)
 	}
@@ -308,7 +507,7 @@ func Test_GetTasksToAllocateRequestedGPUs(t *testing.T) {
 
 func Test_GetTasksToAllocateInitResourceVector(t *testing.T) {
 	// Nil case
-	res := GetTasksToAllocateInitResourceVector(nil, subGroupOrderFn, tasksOrderFn, true, nil)
+	res := GetTasksToAllocateInitResourceVector(nil, subGroupOrderFn, tasksOrderFn, RealTaskAllocation, nil)
 	if res != nil {
 		t.Error("nil expected for nil pg")
 	}
@@ -331,7 +530,7 @@ func Test_GetTasksToAllocateInitResourceVector(t *testing.T) {
 	task2.VectorMap = vectorMap
 	pg.AddTaskInfo(task2)
 
-	vec := GetTasksToAllocateInitResourceVector(pg, subGroupOrderFn, tasksOrderFn, true, nil)
+	vec := GetTasksToAllocateInitResourceVector(pg, subGroupOrderFn, tasksOrderFn, RealTaskAllocation, nil)
 	cpuIdx := resource_info.CPUIndex
 	memIdx := resource_info.MemoryIndex
 	gpuIdx := resource_info.GPUIndex
@@ -347,7 +546,7 @@ func Test_GetTasksToAllocateInitResourceVector(t *testing.T) {
 	}
 
 	// Caching: second call should return same slice
-	vec2 := GetTasksToAllocateInitResourceVector(pg, subGroupOrderFn, tasksOrderFn, true, nil)
+	vec2 := GetTasksToAllocateInitResourceVector(pg, subGroupOrderFn, tasksOrderFn, RealTaskAllocation, nil)
 	if len(vec) != len(vec2) {
 		t.Fatal("cached vector length mismatch")
 	}

--- a/pkg/scheduler/api/podgroup_info/job_info.go
+++ b/pkg/scheduler/api/podgroup_info/job_info.go
@@ -88,11 +88,11 @@ type PodGroupInfo struct {
 	schedulingConstraintsSignature common_info.SchedulingConstraintsSignature
 
 	// inner cache
-	allPodsMap                        *pod_info.PodsMap
-	tasksToAllocate                   []*pod_info.PodInfo
-	tasksToAllocateInitResourceVector resource_info.ResourceVector
-	PodStatusIndex                    map[pod_status.PodStatus]pod_info.PodsMap
-	activeAllocatedCount              *int
+	allPodsMap                              *pod_info.PodsMap
+	tasksToAllocateByMode                   map[taskAllocationCacheMode][]*pod_info.PodInfo
+	tasksToAllocateInitResourceVectorByMode map[taskAllocationCacheMode]resource_info.ResourceVector
+	PodStatusIndex                          map[pod_status.PodStatus]pod_info.PodsMap
+	activeAllocatedCount                    *int
 }
 
 func NewPodGroupInfo(uid common_info.PodGroupID, tasks ...*pod_info.PodInfo) *PodGroupInfo {
@@ -363,8 +363,8 @@ func (pgi *PodGroupInfo) deleteTaskIndex(ti *pod_info.PodInfo) {
 
 func (pgi *PodGroupInfo) invalidateTasksCache() {
 	pgi.allPodsMap = nil
-	pgi.tasksToAllocate = nil
-	pgi.tasksToAllocateInitResourceVector = nil
+	pgi.tasksToAllocateByMode = nil
+	pgi.tasksToAllocateInitResourceVectorByMode = nil
 }
 
 func (pgi *PodGroupInfo) GetActiveAllocatedTasksCount() int {
@@ -501,21 +501,14 @@ func (pgi *PodGroupInfo) IsStale() bool {
 	if totalActivePods == 0 {
 		return false
 	}
-	for _, podSet := range pgi.PodSets {
-		if !podSet.IsGangSatisfied() {
-			return true
-		}
-	}
-	return false
+	return !pgi.IsGangSatisfied()
 }
 
 func (pgi *PodGroupInfo) IsGangSatisfied() bool {
-	for _, podSet := range pgi.PodSets {
-		if !podSet.IsGangSatisfied() {
-			return false
-		}
+	if pgi.RootSubGroupSet == nil {
+		return false
 	}
-	return true
+	return pgi.RootSubGroupSet.IsGangSatisfied()
 }
 
 func (pgi *PodGroupInfo) ShouldPipelineJob() bool {

--- a/pkg/scheduler/api/podgroup_info/job_info_test.go
+++ b/pkg/scheduler/api/podgroup_info/job_info_test.go
@@ -1589,12 +1589,14 @@ func TestPodGroupInfo_IsStale(t *testing.T) {
 			name: "activeUsedTasks >= minAvailable, subgroups gang NOT satisfied, stale",
 			job: func() *PodGroupInfo {
 				pgi := NewPodGroupInfo("test-podgroup")
+				root := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
 
 				sg1 := subgroup_info.NewPodSet("sg1", 1, nil)
-				pgi.PodSets["sg1"] = sg1
-
 				sg2 := subgroup_info.NewPodSet("sg2", 1, nil)
-				pgi.PodSets["sg2"] = sg2
+				root.AddPodSet(sg1)
+				root.AddPodSet(sg2)
+				pgi.RootSubGroupSet = root
+				pgi.PodSets = root.GetDescendantPodSets()
 
 				task1 := pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1628,16 +1630,86 @@ func TestPodGroupInfo_IsStale(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "activeUsedTasks >= minAvailable, subgroups gang satisfied, not stale",
+			name: "minSubGroup satisfied with unready optional subgroup, not stale",
+			job: func() *PodGroupInfo {
+				pgi := NewPodGroupInfo("test-podgroup")
+				root := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
+				minSubGroup := int32(1)
+				root.SetMinSubGroup(&minSubGroup)
+
+				readyPodSet := subgroup_info.NewPodSet("ready", 1, nil)
+				unreadyPodSet := subgroup_info.NewPodSet("unready", 2, nil)
+				root.AddPodSet(readyPodSet)
+				root.AddPodSet(unreadyPodSet)
+				pgi.RootSubGroupSet = root
+				pgi.PodSets = root.GetDescendantPodSets()
+
+				pgi.AddTaskInfo(pod_info.NewTaskInfo(&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "1",
+						Namespace: "ns",
+						Name:      "ready-task",
+						Labels: map[string]string{
+							commonconstants.SubGroupLabelKey: "ready",
+						},
+					},
+					Status: v1.PodStatus{Phase: v1.PodRunning},
+				}, resource_info.NewResourceVectorMap()))
+				pgi.AddTaskInfo(pod_info.NewTaskInfo(&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "2",
+						Namespace: "ns",
+						Name:      "unready-task",
+						Labels: map[string]string{
+							commonconstants.SubGroupLabelKey: "unready",
+						},
+					},
+					Status: v1.PodStatus{Phase: v1.PodPending},
+				}, resource_info.NewResourceVectorMap()))
+
+				return pgi
+			}(),
+			expected: false,
+		},
+		{
+			name: "nested minSubGroup satisfied with optional branch below leaf minimum, not stale",
 			job: func() *PodGroupInfo {
 				pgi := NewPodGroupInfo("test-podgroup")
 
+				readyBranch := subgroup_info.NewSubGroupSet("ready-branch", nil)
+				readyBranch.SetMinSubGroup(ptr.To(int32(1)))
+				readyBranch.AddPodSet(subgroup_info.NewPodSet("ready-leaf", 1, nil))
+				readyBranch.AddPodSet(subgroup_info.NewPodSet("optional-leaf", 2, nil))
+
+				optionalBranch := subgroup_info.NewSubGroupSet("optional-branch", nil)
+				optionalBranch.AddPodSet(subgroup_info.NewPodSet("incomplete-leaf", 2, nil))
+
+				root := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
+				root.SetMinSubGroup(ptr.To(int32(1)))
+				root.AddSubGroup(readyBranch)
+				root.AddSubGroup(optionalBranch)
+				pgi.RootSubGroupSet = root
+				pgi.PodSets = root.GetDescendantPodSets()
+
+				pgi.AddTaskInfo(simpleTask("ready-task", "ready-leaf", pod_status.Running))
+				pgi.AddTaskInfo(simpleTask("optional-task", "optional-leaf", pod_status.Pending))
+				pgi.AddTaskInfo(simpleTask("incomplete-task", "incomplete-leaf", pod_status.Running))
+				return pgi
+			}(),
+			expected: false,
+		},
+		{
+			name: "activeUsedTasks >= minAvailable, subgroups gang satisfied, not stale",
+			job: func() *PodGroupInfo {
+				pgi := NewPodGroupInfo("test-podgroup")
+				root := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
+
 				sg1 := subgroup_info.NewPodSet("sg1", 1, nil)
 				sg2 := subgroup_info.NewPodSet("sg2", 1, nil)
-				pgi.PodSets = map[string]*subgroup_info.PodSet{
-					"sg1": sg1,
-					"sg2": sg2,
-				}
+				root.AddPodSet(sg1)
+				root.AddPodSet(sg2)
+				pgi.RootSubGroupSet = root
+				pgi.PodSets = root.GetDescendantPodSets()
 
 				task1 := pod_info.NewTaskInfo(&v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset.go
+++ b/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset.go
@@ -134,6 +134,22 @@ func (sgs *SubGroupSet) IsMinRequirementSatisfied() bool {
 	return sgs.GetNumActiveAllocatedDirectSubGroups() >= sgs.GetMinMembersToSatisfy()
 }
 
+// IsGangSatisfied reports whether enough direct children satisfy their own gang requirements.
+func (sgs *SubGroupSet) IsGangSatisfied() bool {
+	satisfiedMembers := 0
+	for _, subGroupSet := range sgs.GetDirectSubgroupsSets() {
+		if subGroupSet.IsGangSatisfied() {
+			satisfiedMembers++
+		}
+	}
+	for _, podSet := range sgs.GetDirectPodSets() {
+		if podSet.IsGangSatisfied() {
+			satisfiedMembers++
+		}
+	}
+	return satisfiedMembers >= sgs.GetMinMembersToSatisfy()
+}
+
 func (sgs *SubGroupSet) GetNumActiveAllocatedMembers() int {
 	return sgs.GetNumActiveAllocatedDirectSubGroups()
 }

--- a/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset_test.go
+++ b/pkg/scheduler/api/podgroup_info/subgroup_info/subgroupset_test.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/utils/ptr"
+
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_status"
@@ -252,6 +254,71 @@ func TestSubGroupSet_MinSubGroupZero_AlwaysSatisfied(t *testing.T) {
 			t.Errorf("root.GetNumActiveAllocatedDirectSubGroups() = %d, want 1 (inner is satisfied via minSubGroup=0)", got)
 		}
 	})
+}
+
+func TestSubGroupSet_IsGangSatisfied(t *testing.T) {
+	tests := []struct {
+		name     string
+		root     *SubGroupSet
+		expected bool
+	}{
+		{
+			name: "nested branch satisfied with optional leaf below minimum",
+			root: func() *SubGroupSet {
+				inner := NewSubGroupSet("inner", nil)
+				inner.SetMinSubGroup(ptr.To(int32(1)))
+				inner.AddPodSet(podSetWithRunningPods("ready", 1, 1))
+				inner.AddPodSet(podSetWithRunningPods("optional", 2, 0))
+
+				root := NewSubGroupSet("root", nil)
+				root.AddSubGroup(inner)
+				return root
+			}(),
+			expected: true,
+		},
+		{
+			name: "required nested branch below leaf minimum",
+			root: func() *SubGroupSet {
+				inner := NewSubGroupSet("inner", nil)
+				inner.AddPodSet(podSetWithRunningPods("not-ready", 2, 1))
+
+				root := NewSubGroupSet("root", nil)
+				root.AddSubGroup(inner)
+				return root
+			}(),
+			expected: false,
+		},
+		{
+			name: "minSubGroup zero is satisfied without active leaves",
+			root: func() *SubGroupSet {
+				root := NewSubGroupSet("root", nil)
+				root.SetMinSubGroup(ptr.To(int32(0)))
+				root.AddPodSet(podSetWithRunningPods("optional", 2, 0))
+				return root
+			}(),
+			expected: true,
+		},
+		{
+			name: "releasing leaf remains gang satisfied",
+			root: func() *SubGroupSet {
+				podSet := NewPodSet("releasing", 1, nil)
+				podSet.AssignTask(&pod_info.PodInfo{UID: "releasing-1", Status: pod_status.Releasing})
+
+				root := NewSubGroupSet("root", nil)
+				root.AddPodSet(podSet)
+				return root
+			}(),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.root.IsGangSatisfied(); got != tt.expected {
+				t.Errorf("IsGangSatisfied() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
 }
 
 func TestGetNumActiveAllocatedDirectSubGroups(t *testing.T) {

--- a/pkg/scheduler/cache/cluster_info/cluster_info.go
+++ b/pkg/scheduler/cache/cluster_info/cluster_info.go
@@ -441,7 +441,7 @@ func (c *ClusterInfo) snapshotPodGroups(
 
 	result := map[common_info.PodGroupID]*podgroup_info.PodGroupInfo{}
 	for _, podGroup := range podGroups {
-		podGroupID := common_info.PodGroupID(podGroup.Name)
+		podGroupID := common_info.NewPodGroupID(podGroup.Namespace, podGroup.Name)
 		podGroupInfo := podgroup_info.NewPodGroupInfoWithVectorMap(podGroupID, vectorMap)
 
 		if err := validatePodgroupQueue(existingQueues, podGroup); err != nil {
@@ -453,7 +453,7 @@ func (c *ClusterInfo) snapshotPodGroups(
 		}
 
 		c.setPodGroupWithIndex(podGroup, podGroupInfo)
-		rawPods, err := c.dataLister.ListPodByIndex(podByPodGroupIndexerName, podGroup.Name)
+		rawPods, err := c.dataLister.ListPodByIndex(podByPodGroupIndexerName, string(podGroupID))
 		if err != nil {
 			log.InfraLogger.Errorf("failed to get indexed pods: %s", err)
 			return nil, err
@@ -464,10 +464,11 @@ func (c *ClusterInfo) snapshotPodGroups(
 				log.InfraLogger.Errorf("Snapshot podGroups: Error getting pod from rawPod: %v", rawPod)
 			}
 			podInfo := c.getPodInfo(pod, existingPods, vectorMap)
+			podInfo.Job = podGroupID
 			podGroupInfo.AddTaskInfo(podInfo)
 		}
 
-		result[common_info.PodGroupID(podGroup.Name)] = podGroupInfo
+		result[podGroupID] = podGroupInfo
 	}
 
 	return result, nil

--- a/pkg/scheduler/cache/cluster_info/cluster_info_test.go
+++ b/pkg/scheduler/cache/cluster_info/cluster_info_test.go
@@ -1151,8 +1151,9 @@ func TestSnapshotPodGroups(t *testing.T) {
 			objs: []runtime.Object{
 				&enginev2alpha2.PodGroup{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "podGroup-0",
-						UID:  "ABC",
+						Namespace: testNamespace,
+						Name:      "podGroup-0",
+						UID:       "ABC",
 					},
 					Spec: enginev2alpha2.PodGroupSpec{
 						Queue:     "queue-0",
@@ -1226,6 +1227,7 @@ func TestSnapshotPodGroups(t *testing.T) {
 					subGroupSet.AddPodSet(subGroup1)
 
 					return &podgroup_info.PodGroupInfo{
+						Namespace:       testNamespace,
 						Name:            "podGroup-0",
 						Queue:           "queue-0",
 						RootSubGroupSet: subGroupSet,
@@ -1241,8 +1243,9 @@ func TestSnapshotPodGroups(t *testing.T) {
 			objs: []runtime.Object{
 				&enginev2alpha2.PodGroup{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "podGroup-0",
-						UID:  "ABC",
+						Namespace: testNamespace,
+						Name:      "podGroup-0",
+						UID:       "ABC",
 					},
 					Spec: enginev2alpha2.PodGroupSpec{
 						Queue: "queue-0",
@@ -1292,6 +1295,7 @@ func TestSnapshotPodGroups(t *testing.T) {
 					subGroupSet.AddPodSet(subGroup0)
 
 					return &podgroup_info.PodGroupInfo{
+						Namespace:       testNamespace,
 						Name:            "podGroup-0",
 						Queue:           "queue-0",
 						RootSubGroupSet: subGroupSet,
@@ -1302,7 +1306,7 @@ func TestSnapshotPodGroups(t *testing.T) {
 				}(),
 			},
 			invalidSubGroupTasks: map[common_info.PodGroupID][]common_info.PodID{
-				"podGroup-0": {common_info.PodID(fmt.Sprintf("%s/pod-invalid", testNamespace))},
+				common_info.NewPodGroupID(testNamespace, "podGroup-0"): {common_info.PodID(fmt.Sprintf("%s/pod-invalid", testNamespace))},
 			},
 		},
 	}
@@ -1325,7 +1329,8 @@ func TestSnapshotPodGroups(t *testing.T) {
 
 		assert.Equal(t, len(test.results), len(podGroups))
 		for _, expected := range test.results {
-			pg, found := podGroups[common_info.PodGroupID(expected.Name)]
+			podGroupID := common_info.NewPodGroupID(expected.Namespace, expected.Name)
+			pg, found := podGroups[podGroupID]
 			assert.True(t, found, "PodGroup not found", expected.Name)
 
 			assert.Equal(t, expected.Name, pg.Name)
@@ -1348,13 +1353,67 @@ func TestSnapshotPodGroups(t *testing.T) {
 				}
 			}
 
-			expectedInvalidTasks := test.invalidSubGroupTasks[common_info.PodGroupID(expected.Name)]
+			expectedInvalidTasks := test.invalidSubGroupTasks[podGroupID]
 			assert.Len(t, pg.GetInvalidSubGroupTasks(), len(expectedInvalidTasks))
 			for _, taskID := range expectedInvalidTasks {
 				assert.Contains(t, pg.GetInvalidSubGroupTasks(), taskID)
 			}
 		}
 
+	}
+}
+
+func TestSnapshotPodGroupsWithSameNameInDifferentNamespaces(t *testing.T) {
+	const podGroupName = "shared-name"
+	namespaces := []string{"live", "shadow"}
+
+	podGroups := make([]runtime.Object, 0, len(namespaces))
+	pods := make([]runtime.Object, 0, len(namespaces))
+	for _, namespace := range namespaces {
+		podGroups = append(podGroups, &enginev2alpha2.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      podGroupName,
+				UID:       types.UID(namespace + "-podgroup"),
+			},
+			Spec: enginev2alpha2.PodGroupSpec{Queue: "queue-0"},
+		})
+		pods = append(pods, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      namespace + "-pod",
+				UID:       types.UID(namespace + "-pod"),
+				Annotations: map[string]string{
+					commonconstants.PodGroupAnnotationForPod: podGroupName,
+				},
+			},
+		})
+	}
+
+	clusterInfo := newClusterInfoTests(t, clusterInfoTestParams{
+		kubeObjects:         pods,
+		kaiSchedulerObjects: podGroups,
+	})
+	result, err := clusterInfo.snapshotPodGroups(
+		map[common_info.QueueID]*queue_info.QueueInfo{"queue-0": {Name: "queue-0"}},
+		map[common_info.PodID]*pod_info.PodInfo{},
+		resource_info.NewResourceVectorMap(),
+	)
+	assert.NoError(t, err)
+	assert.Len(t, result, len(namespaces))
+
+	for _, namespace := range namespaces {
+		podGroupID := common_info.NewPodGroupID(namespace, podGroupName)
+		podGroup, found := result[podGroupID]
+		if !assert.True(t, found, "PodGroup not found: %s", podGroupID) {
+			continue
+		}
+		assert.Equal(t, namespace, podGroup.Namespace)
+		assert.Len(t, podGroup.GetAllPodsMap(), 1)
+		for _, pod := range podGroup.GetAllPodsMap() {
+			assert.Equal(t, namespace, pod.Namespace)
+			assert.Equal(t, podGroupID, pod.Job)
+		}
 	}
 }
 
@@ -1397,7 +1456,7 @@ func TestSnapshotPodGroups_QueueDoesNotExist_AddsJobFitError(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(podGroups), "Expected 1 podgroup even with missing queue")
 
-	pg, found := podGroups[common_info.PodGroupID("podGroup-missing-queue")]
+	pg, found := podGroups[common_info.NewPodGroupID(testNamespace, "podGroup-missing-queue")]
 	assert.True(t, found, "PodGroup not found")
 	assert.Equal(t, "nonexistent-queue", string(pg.Queue))
 
@@ -2110,8 +2169,9 @@ func TestNotSchedulingPodWithTerminatingPVC(t *testing.T) {
 		},
 		&enginev2alpha2.PodGroup{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "podGroup-0",
-				UID:  "ABC",
+				Namespace: "test",
+				Name:      "podGroup-0",
+				UID:       "ABC",
 			},
 			Spec: enginev2alpha2.PodGroupSpec{
 				Queue: "queue-0",
@@ -2128,7 +2188,8 @@ func TestNotSchedulingPodWithTerminatingPVC(t *testing.T) {
 	snapshot, err := clusterInfo.Snapshot()
 	assert.Equal(t, nil, err)
 	node := snapshot.Nodes["node-1"]
-	task := snapshot.PodGroupInfos["podGroup-0"].GetAllPodsMap()["pod-1"]
+	podGroupID := common_info.NewPodGroupID("test", "podGroup-0")
+	task := snapshot.PodGroupInfos[podGroupID].GetAllPodsMap()["pod-1"]
 	assert.Equal(t, node.IsTaskAllocatable(task), false)
 
 	pvc.OwnerReferences = nil
@@ -2142,7 +2203,7 @@ func TestNotSchedulingPodWithTerminatingPVC(t *testing.T) {
 	snapshot, err = clusterInfo.Snapshot()
 	assert.Equal(t, nil, err)
 	node = snapshot.Nodes["node-1"]
-	task = snapshot.PodGroupInfos["podGroup-0"].GetAllPodsMap()["pod-1"]
+	task = snapshot.PodGroupInfos[podGroupID].GetAllPodsMap()["pod-1"]
 	assert.Equal(t, node.IsTaskAllocatable(task), true, "Expected task to be allocatable, but got %v", node.IsTaskAllocatable(task))
 }
 

--- a/pkg/scheduler/cache/cluster_info/indexers.go
+++ b/pkg/scheduler/cache/cluster_info/indexers.go
@@ -7,6 +7,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	commonconstants "github.com/kai-scheduler/KAI-scheduler/pkg/common/constants"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/common_info"
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/log"
 )
 
@@ -22,5 +23,8 @@ func podByPodGroupIndexer(obj interface{}) ([]string, error) {
 	}
 
 	podGroup := pod.Annotations[commonconstants.PodGroupAnnotationForPod]
-	return []string{podGroup}, nil
+	if podGroup == "" {
+		return []string{""}, nil
+	}
+	return []string{string(common_info.NewPodGroupID(pod.Namespace, podGroup))}, nil
 }

--- a/pkg/scheduler/cache/cluster_info/indexers_test.go
+++ b/pkg/scheduler/cache/cluster_info/indexers_test.go
@@ -16,6 +16,7 @@ import (
 func TestPodByPodGroupIndexerValidPod(t *testing.T) {
 	pod := &v1.Pod{
 		ObjectMeta: v12.ObjectMeta{
+			Namespace: "my-namespace",
 			Annotations: map[string]string{
 				commonconstants.PodGroupAnnotationForPod: "my-pod-group",
 			},
@@ -26,7 +27,7 @@ func TestPodByPodGroupIndexerValidPod(t *testing.T) {
 
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 1, len(podGroups))
-	assert.Equal(t, "my-pod-group", podGroups[0])
+	assert.Equal(t, "my-namespace/my-pod-group", podGroups[0])
 }
 
 func TestPodByPodGroupIndexerNotPod(t *testing.T) {
@@ -37,4 +38,13 @@ func TestPodByPodGroupIndexerNotPod(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, 1, len(podGroups))
 	assert.Equal(t, "", podGroups[0])
+}
+
+func TestPodByPodGroupIndexerPodWithoutPodGroup(t *testing.T) {
+	pod := &v1.Pod{ObjectMeta: v12.ObjectMeta{Namespace: "my-namespace"}}
+
+	podGroups, err := podByPodGroupIndexer(pod)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{""}, podGroups)
 }

--- a/pkg/scheduler/plugins/numa/consolidation_discard_test.go
+++ b/pkg/scheduler/plugins/numa/consolidation_discard_test.go
@@ -108,11 +108,14 @@ func (f *scenarioFixture) runScenario(t *testing.T) {
 	require.Equal(t, int64(4), f.zone(0), "evicting both victims frees zone 0")
 	require.Equal(t, int64(4), f.zone(1), "evicting both victims frees zone 1")
 
-	require.True(t, common.AllocateJob(f.ssn, f.stmt, f.nodes, f.preemptorJob, true), "preemptor pipelines onto freed zone 0")
+	require.True(t, common.AllocateJob(f.ssn, f.stmt, f.nodes, f.preemptorJob,
+		podgroup_info.SimulatedTaskAllocation), "preemptor pipelines onto freed zone 0")
 	// Re-pipeline the evicted victim jobs. victim0 re-homes to the now-only-free zone 1;
 	// victim1 cannot fit and stays evicted — this asymmetry is what the simple hand-trace misses.
-	common.AllocateJob(f.ssn, f.stmt, f.nodes, f.ssn.ClusterInfo.PodGroupInfos["victim0"], true)
-	common.AllocateJob(f.ssn, f.stmt, f.nodes, f.ssn.ClusterInfo.PodGroupInfos["victim1"], true)
+	common.AllocateJob(f.ssn, f.stmt, f.nodes, f.ssn.ClusterInfo.PodGroupInfos["victim0"],
+		podgroup_info.VictimReallocation)
+	common.AllocateJob(f.ssn, f.stmt, f.nodes, f.ssn.ClusterInfo.PodGroupInfos["victim1"],
+		podgroup_info.VictimReallocation)
 
 	// Mid-scenario (before any unwind): the real allocateTaskToNode stamp must have re-homed
 	// victim0 to the free zone 1 so the dedup did NOT restore+recharge its stale zone-0 placement

--- a/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy_test.go
+++ b/pkg/scheduler/plugins/proportion/capacity_policy/capacity_policy_test.go
@@ -375,8 +375,7 @@ var _ = Describe("Capacity Policy Check", func() {
 				testData := data
 				It(testName, func() {
 					capacityPolicy := New(testData.queues, ptr.To[int64](node_info.DefaultGpuMemory))
-					tasksToAllocate := podgroup_info.GetTasksToAllocate(testData.job, dummyTasksLessThen,
-						dummyTasksLessThen, true)
+					tasksToAllocate := getTasksToAllocate(testData.job)
 					result := capacityPolicy.IsJobOverQueueCapacity(testData.job, tasksToAllocate)
 					Expect(result.IsSchedulable).To(Equal(testData.expectedResult))
 				})
@@ -534,8 +533,7 @@ var _ = Describe("Capacity Policy Check", func() {
 				testData := data
 				It(testName, func() {
 					capacityPolicy := New(testData.queues, ptr.To[int64](node_info.DefaultGpuMemory))
-					tasksToAllocate := podgroup_info.GetTasksToAllocate(testData.job, dummyTasksLessThen,
-						dummyTasksLessThen, true)
+					tasksToAllocate := getTasksToAllocate(testData.job)
 					result := capacityPolicy.IsJobOverQueueCapacity(testData.job, tasksToAllocate)
 					Expect(result.IsSchedulable).To(Equal(testData.expectedResult))
 				})
@@ -696,8 +694,7 @@ var _ = Describe("Capacity Policy Check", func() {
 				testData := data
 				It(testName, func() {
 					capacityPolicy := New(testData.queues, ptr.To[int64](node_info.DefaultGpuMemory))
-					tasksToAllocate := podgroup_info.GetTasksToAllocate(testData.job, dummyTasksLessThen,
-						dummyTasksLessThen, true)
+					tasksToAllocate := getTasksToAllocate(testData.job)
 					result := capacityPolicy.IsNonPreemptibleJobOverQuota(testData.job, tasksToAllocate)
 					Expect(result.IsSchedulable).To(Equal(testData.expectedResult))
 				})
@@ -1432,4 +1429,15 @@ var _ = Describe("Capacity Policy Check", func() {
 
 func dummyTasksLessThen(_ interface{}, _ interface{}) bool {
 	return false
+}
+
+func getTasksToAllocate(job *podgroup_info.PodGroupInfo) []*pod_info.PodInfo {
+	root := subgroup_info.NewSubGroupSet(subgroup_info.RootSubGroupSetName, nil)
+	for _, podSet := range job.PodSets {
+		root.AddPodSet(podSet)
+	}
+	job.RootSubGroupSet = root
+	return podgroup_info.GetTasksToAllocate(
+		job, dummyTasksLessThen, dummyTasksLessThen, podgroup_info.RealTaskAllocation,
+	)
 }

--- a/pkg/scheduler/plugins/proportion/proportion.go
+++ b/pkg/scheduler/plugins/proportion/proportion.go
@@ -137,21 +137,23 @@ func (pp *proportionPlugin) OnJobSolutionStartFn() {
 }
 
 func (pp *proportionPlugin) CanReclaimResourcesFn(reclaimer *podgroup_info.PodGroupInfo) bool {
-	reclaimerInfo := pp.buildReclaimerInfo(reclaimer, pp.minNodeGPUMemory)
+	reclaimerInfo := pp.buildReclaimerInfo(reclaimer, pp.minNodeGPUMemory, podgroup_info.PartialTaskAllocation)
 	return pp.reclaimablePlugin.CanReclaimResources(pp.queues, &reclaimerInfo)
 }
 
 func (pp *proportionPlugin) reclaimVictimFilterFn(
 	reclaimer *podgroup_info.PodGroupInfo, victim *podgroup_info.PodGroupInfo,
 ) bool {
-	reclaimerInfo := pp.buildReclaimerInfo(reclaimer, pp.minNodeGPUMemory)
+	reclaimerInfo := pp.buildReclaimerInfo(reclaimer, pp.minNodeGPUMemory, podgroup_info.PartialTaskAllocation)
 	return pp.reclaimablePlugin.FilterVictim(pp.queues, &reclaimerInfo, victim.Queue)
 }
 
 func (pp *proportionPlugin) reclaimableFn(
 	scenario api.ScenarioInfo,
 ) bool {
-	reclaimerInfo := pp.buildReclaimerInfo(scenario.GetPreemptor(), pp.minNodeGPUMemory)
+	reclaimerInfo := pp.buildReclaimerInfo(
+		scenario.GetPreemptor(), pp.minNodeGPUMemory, podgroup_info.PartialTaskAllocation,
+	)
 	totalVictimsResources := make(map[common_info.QueueID][]resource_info.ResourceVector)
 	victims := scenario.GetVictims()
 	for _, victim := range victims {
@@ -303,14 +305,16 @@ func (pp *proportionPlugin) createQueueAttributes(ssn *framework.Session) {
 	pp.setFairShare()
 }
 
-func (pp *proportionPlugin) buildReclaimerInfo(reclaimer *podgroup_info.PodGroupInfo, minNodeGPUMemory *int64) rec.ReclaimerInfo {
+func (pp *proportionPlugin) buildReclaimerInfo(
+	reclaimer *podgroup_info.PodGroupInfo, minNodeGPUMemory *int64, allocationMode podgroup_info.TaskAllocationMode,
+) rec.ReclaimerInfo {
 	return rec.ReclaimerInfo{
 		Name:          reclaimer.Name,
 		Namespace:     reclaimer.Namespace,
 		Queue:         reclaimer.Queue,
 		IsPreemptable: reclaimer.IsPreemptibleJob(),
 		RequiredResources: podgroup_info.GetTasksToAllocateInitResourceVector(reclaimer, pp.subGroupOrderFn, pp.taskOrderFunc,
-			false, minNodeGPUMemory),
+			allocationMode, minNodeGPUMemory),
 		VectorMap: reclaimer.VectorMap,
 	}
 }

--- a/pkg/scheduler/plugins/proportion/proportion_test.go
+++ b/pkg/scheduler/plugins/proportion/proportion_test.go
@@ -52,7 +52,7 @@ func TestBuildReclaimerInfoDoesNotAllocate(t *testing.T) {
 	var info rec.ReclaimerInfo
 
 	allocations := testing.AllocsPerRun(100, func() {
-		info = plugin.buildReclaimerInfo(reclaimer, nil)
+		info = plugin.buildReclaimerInfo(reclaimer, nil, podgroup_info.PartialTaskAllocation)
 	})
 
 	if info.Name != reclaimer.Name || info.Namespace != reclaimer.Namespace || info.Queue != reclaimer.Queue {

--- a/pkg/scheduler/plugins/proportion/queue_order/queue_order.go
+++ b/pkg/scheduler/plugins/proportion/queue_order/queue_order.go
@@ -37,7 +37,7 @@ func jobInitResources(
 		return nil
 	}
 	return podgroup_info.GetTasksToAllocateInitResourceVector(
-		jobInfo, subGroupOrderFn, taskOrderFn, false, minNodeGPUMemory,
+		jobInfo, subGroupOrderFn, taskOrderFn, podgroup_info.PartialTaskAllocation, minNodeGPUMemory,
 	)
 }
 

--- a/pkg/scheduler/plugins/topology/job_filtering_test.go
+++ b/pkg/scheduler/plugins/topology/job_filtering_test.go
@@ -603,7 +603,8 @@ func TestTopologyPlugin_subsetNodesFn(t *testing.T) {
 
 			// Call the function under test
 			subsets, err := plugin.subSetNodesFn(job, &job.RootSubGroupSet.SubGroupInfo,
-				job.RootSubGroupSet.GetDescendantPodSets(), podgroup_info.GetTasksToAllocate(job, nil, nil, true),
+				job.RootSubGroupSet.GetDescendantPodSets(), podgroup_info.GetTasksToAllocate(job, nil, nil,
+					podgroup_info.RealTaskAllocation),
 				maps.Values(nodesInfoMap))
 
 			// Check error
@@ -1540,7 +1541,8 @@ func TestTopologyPlugin_calcTreeAllocatable(t *testing.T) {
 			plugin := &topologyPlugin{}
 
 			// Call the function under test
-			err := plugin.calcTreeAllocatable(podgroup_info.GetTasksToAllocate(job, nil, nil, true), topologyTree.DomainsByLevel[rootLevel][rootDomainId])
+			err := plugin.calcTreeAllocatable(podgroup_info.GetTasksToAllocate(job, nil, nil,
+				podgroup_info.RealTaskAllocation), topologyTree.DomainsByLevel[rootLevel][rootDomainId])
 			if err != nil {
 				t.Errorf("failed to calc tree allocatable. job: %s, error: %v", job.PodGroup.Name, err)
 			}
@@ -2182,7 +2184,7 @@ func TestTopologyPlugin_getJobAllocatableDomains(t *testing.T) {
 				[]*jobs_fake.TestJobBasic{tt.job}, testVectorMap)
 			job := jobsInfoMap[common_info.PodGroupID(tt.job.Name)]
 
-			tasks := podgroup_info.GetTasksToAllocate(job, nil, nil, true)
+			tasks := podgroup_info.GetTasksToAllocate(job, nil, nil, podgroup_info.RealTaskAllocation)
 			tasksResources := resource_info.NewResource(0, 0, 0)
 			for _, task := range tasks {
 				tasksResources.AddVectorAndGpuReq(task.ResReqVector, task.VectorMap, &task.GpuRequirement)

--- a/test/e2e/suites/allocate/min_subgroups/min_subgroups_test.go
+++ b/test/e2e/suites/allocate/min_subgroups/min_subgroups_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -92,6 +93,35 @@ var _ = Describe("Single-level hierarchy with minSubGroup", Ordered, func() {
 		namespace := queue.GetConnectedNamespaceToQueue(testCtx.Queues[0])
 		wait.ForAtLeastNPodsScheduled(ctx, testCtx.ControllerClient, namespace, h.AllPods, 6)
 		wait.ForAtLeastNPodsUnschedulable(ctx, testCtx.ControllerClient, namespace, h.AllPods, 2)
+	})
+
+	// A leaf holding fewer pods than its own minMember must never be allocated, even
+	// when the PodGroup as a whole is schedulable. "filler" satisfies the root's
+	// minSubGroup=1 on its own, so the PodGroup passes the scheduler's readiness gate
+	// and is never filtered out of the allocate queue. "starved" requires 2 members but
+	// holds a single pod, so its gang can never be formed and it must stay pending
+	// regardless of how much capacity is free.
+	It("should not schedule a leaf holding fewer pods than its own minMember", func(ctx context.Context) {
+		_, h := pod_group.CreateWithHierarchy(ctx, testCtx.KubeClientset, testCtx.KubeAiSchedClientset,
+			utils.GenerateRandomK8sName(10), testCtx.Queues[0], ptr.To[int32](1),
+			[]pod_group.SubGroupNode{
+				{Name: "filler", MinMember: ptr.To[int32](1), PodCount: 1},
+				{Name: "starved", MinMember: ptr.To[int32](2), PodCount: 1},
+			}, nil, "", cpuPerPod)
+
+		namespace := queue.GetConnectedNamespaceToQueue(testCtx.Queues[0])
+		wait.ForAtLeastNPodsScheduled(ctx, testCtx.ControllerClient, namespace, h.Pods["filler"], 1)
+
+		// Asserted with Consistently rather than ForAtLeastNPodsUnschedulable: the
+		// scheduler never attempts allocation for this pod, so it carries no
+		// PodScheduled=False condition to wait on.
+		starvedPod := h.Pods["starved"][0]
+		Consistently(func(g Gomega) {
+			pod, err := testCtx.KubeClientset.CoreV1().Pods(namespace).
+				Get(ctx, starvedPod.Name, metav1.GetOptions{})
+			g.Expect(err).To(Succeed())
+			g.Expect(rd.IsPodScheduled(pod)).To(BeFalse())
+		}).WithTimeout(30 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
 	})
 
 	It("should not schedule when minSubGroup cannot be satisfied", func(ctx context.Context) {


### PR DESCRIPTION
## Description

Backports both scheduler fixes from the multi-node gang-scheduling investigation to `v0.17`, as discussed with @itsomri. Neither is on `v0.17`, so `v0.17.1` does not carry them:

- #2095 — `fix(scheduler): namespace PodGroup identities` (merged to `main` as 06b86d66)
- #2096 — `fix(scheduler): enforce PodSet gang admission floor` (merged to `main` as b1a4be07)


## Related Issues

Backport of #2095 and #2096. 
## Checklist

- [x] Self-reviewed
- [x] Added/updated tests (carried from the original PRs, including the e2e case from #2099)
- [x] Updated documentation (not needed; no API or configuration change)
- [x] Added a changelog fragment via `make changelog` (both original changie fragments are carried in the cherry-picks)

## Breaking Changes

None.

## Additional Notes

**#2095** applied clean, no conflicts.

**#2096** had one conflict, in `pkg/scheduler/api/podgroup_info/job_info.go`. `main` memoizes `GetAliveTasksRequestedGPUs` behind a `PodGroupInfo.aliveTasksRequestedGPUs` field, which arrived with #1995 (gpujoborder plugin) and is not on `v0.17`. The resolution takes the #2096 side and drops that field plus its reset in `invalidateTasksCache`, leaving `v0.17`'s existing uncached implementation in place. That is the only deviation from `main`: diffing all 29 files touched by #2096 between this branch and b1a4be07 shows `job_info.go` alone, and only those hunks.
