### PR TITLE
fix(scheduler): consistent resourceList parsing for resourceInfo and node vector

### DIFF
--- a/.changes/unreleased/fixed-20260907-220926.yaml
+++ b/.changes/unreleased/fixed-20260907-220926.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Bug fix: consistent resourceList parsing for resourceInfo and node vector

--- a/pkg/scheduler/api/common_info/job_errors_test.go
+++ b/pkg/scheduler/api/common_info/job_errors_test.go
@@ -445,7 +445,7 @@ func TestNewTopologyInsufficientResourcesError(t *testing.T) {
 					subGroupName:     "subgroup1",
 					reason:           UnschedulableWorkloadReason,
 					messages:         []string{"node-group(s) didn't have enough resources: custom.io/res"},
-					detailedMessages: []string{"domain1 didn't have enough resource: custom.io/res, requested: 5000, available: 3000"},
+					detailedMessages: []string{"domain1 didn't have enough resource: custom.io/res, requested: 5, available: 3"},
 				},
 				nodesGroupName: "domain1",
 			},

--- a/pkg/scheduler/api/resource_info/base_resources.go
+++ b/pkg/scheduler/api/resource_info/base_resources.go
@@ -13,11 +13,11 @@ import (
 )
 
 const (
-	minMilliCPU             float64 = 10
-	minMilliScalarResources int64   = 10
-	MinMemory               float64 = 10 * 1024 * 1024
-	MilliCPUToCores         float64 = 1000
-	MemoryToGB              float64 = 1000 * 1000 * 1000
+	minMilliCPU        float64 = 10
+	minScalarResources int64   = 0
+	MinMemory          float64 = 10 * 1024 * 1024
+	MilliCPUToCores    float64 = 1000
+	MemoryToGB         float64 = 1000 * 1000 * 1000
 )
 
 type BaseResource struct {
@@ -110,7 +110,7 @@ func (r *BaseResource) ToResourceList() v1.ResourceList {
 	rl[v1.ResourceCPU] = *resource.NewMilliQuantity(int64(r.milliCpu), resource.DecimalSI)
 	rl[v1.ResourceMemory] = *resource.NewQuantity(int64(r.memory), resource.DecimalSI)
 	for rName, rQuant := range r.scalarResources {
-		rl[rName] = *resource.NewMilliQuantity(int64(rQuant), resource.DecimalSI)
+		rl[rName] = *resource.NewQuantity(int64(rQuant), resource.DecimalSI)
 	}
 
 	return rl
@@ -121,7 +121,7 @@ func (r *BaseResource) IsEmpty() bool {
 		return false
 	}
 	for _, rQuant := range r.scalarResources {
-		if rQuant >= minMilliScalarResources {
+		if rQuant >= minScalarResources {
 			return false
 		}
 	}

--- a/pkg/scheduler/api/resource_info/base_resources.go
+++ b/pkg/scheduler/api/resource_info/base_resources.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	minMilliCPU        float64 = 10
-	minScalarResources int64   = 0
+	minScalarResources int64   = 1
 	MinMemory          float64 = 10 * 1024 * 1024
 	MilliCPUToCores    float64 = 1000
 	MemoryToGB         float64 = 1000 * 1000 * 1000

--- a/pkg/scheduler/api/resource_info/resource_info.go
+++ b/pkg/scheduler/api/resource_info/resource_info.go
@@ -71,7 +71,7 @@ func ResourceFromResourceList(rList v1.ResourceList) *Resource {
 			} else if rName == v1.ResourceEphemeralStorage || rName == v1.ResourceStorage {
 				r.scalarResources[rName] += rQuant.Value()
 			} else if k8s_internal.IsScalarResourceName(rName) {
-				r.scalarResources[rName] += rQuant.MilliValue()
+				r.scalarResources[rName] += rQuant.Value()
 			}
 		}
 	}

--- a/pkg/scheduler/api/resource_info/resource_requirment.go
+++ b/pkg/scheduler/api/resource_info/resource_requirment.go
@@ -62,7 +62,7 @@ func RequirementsFromResourceList(rl v1.ResourceList) *ResourceRequirements {
 			if IsMigResource(rName) {
 				r.MigResources()[rName] += rQuant.Value()
 			} else if k8s_internal.IsScalarResourceName(rName) {
-				r.scalarResources[rName] += rQuant.MilliValue()
+				r.scalarResources[rName] += rQuant.Value()
 			} else if rName == v1.ResourceEphemeralStorage || rName == v1.ResourceStorage {
 				r.scalarResources[rName] += rQuant.Value()
 			}

--- a/pkg/scheduler/api/resource_info/resource_requirment_test.go
+++ b/pkg/scheduler/api/resource_info/resource_requirment_test.go
@@ -57,7 +57,7 @@ var _ = Describe("ResourceRequirements Info internal logic", func() {
 				v1.ResourceName("kai.scheduler/test-resource"): resource.MustParse("1"),
 			}
 			resourceInfo := RequirementsFromResourceList(resourceList)
-			Expect(resourceInfo.Get("kai.scheduler/test-resource")).To(Equal(float64(1000)))
+			Expect(resourceInfo.Get("kai.scheduler/test-resource")).To(Equal(float64(1)))
 
 			newResourceList := resourceInfo.ToResourceList()
 			compareResourceLists(resourceList, newResourceList)
@@ -81,7 +81,7 @@ var _ = Describe("ResourceRequirements Info internal logic", func() {
 			clone := resourceInfo.Clone()
 			Expect(clone.Cpu()).To(Equal(float64(1000)))
 			Expect(clone.Memory()).To(Equal(float64(5000000000)))
-			Expect(clone.Get("kai.scheduler/test-resource")).To(Equal(float64(1000)))
+			Expect(clone.Get("kai.scheduler/test-resource")).To(Equal(float64(1)))
 		})
 	})
 
@@ -177,6 +177,21 @@ var _ = Describe("ResourceRequirements Info internal logic", func() {
 				})
 				Expect(resourceInfo2.LessInAtLeastOneResource(resourceInfo1)).To(BeTrue())
 			})
+		})
+
+		It("Extended resources consistent parsing", func() {
+			const rdmaResourceName = v1.ResourceName("intel.com/mlnx_sriov_rdma")
+			resourceList := v1.ResourceList{
+				rdmaResourceName: resource.MustParse("4"),
+			}
+
+			resourceInfo := RequirementsFromResourceList(resourceList)
+			Expect(resourceInfo.Get(rdmaResourceName)).To(Equal(float64(4)))
+
+			// The vector conversion used for node allocatable elsewhere must agree.
+			vectorMap := BuildResourceVectorMap([]v1.ResourceList{resourceList})
+			nodeVector := NewResourceVectorFromResourceList(resourceList, vectorMap)
+			Expect(resourceInfo.ToVector(vectorMap)).To(Equal(nodeVector))
 		})
 	})
 })

--- a/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
+++ b/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
@@ -348,6 +348,45 @@ func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 	}
 }
 
+// Test_extendedResourcesAreNotScaledByThousand reproduces
+// https://github.com/kai-scheduler/KAI-Scheduler/issues/2122: a pod requesting 4
+// units of an extended resource is accounted as 4000 (MilliValue), so a node
+// advertising 8 units is rejected.
+func Test_extendedResourcesAreNotScaledByThousand(t *testing.T) {
+	const rdmaResourceName = v1.ResourceName("intel.com/mlnx_sriov_rdma")
+
+	nodesMap := buildTestNodes(map[string]v1.ResourceList{
+		"n1": {
+			v1.ResourceCPU:                resource.MustParse("96"),
+			v1.ResourceMemory:             resource.MustParse("1000Gi"),
+			resource_info.GPUResourceName: resource.MustParse("8"),
+			v1.ResourcePods:               resource.MustParse("110"),
+			rdmaResourceName:              resource.MustParse("8"),
+		},
+	})
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "name1", Namespace: "n1"},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{rdmaResourceName: resource.MustParse("4")},
+						Limits:   v1.ResourceList{rdmaResourceName: resource.MustParse("4")},
+					},
+				},
+			},
+		},
+	}
+
+	mnr := NewMaxNodeResourcesPredicate(nodesMap, []*resourceapi.ResourceClaim{}, "")
+	_, status := mnr.PreFilter(context.TODO(), nil, pod, nil)
+	if status != nil {
+		t.Fatalf("PreFilter() rejected a pod requesting 4 %s on a node with 8: %v", rdmaResourceName, status.Message())
+	}
+}
+
 func makeDRAResourceSlice(name, nodeName, driver string, deviceCount int) *resourceapi.ResourceSlice {
 	devices := make([]resourceapi.Device, deviceCount)
 	for i := 0; i < deviceCount; i++ {
@@ -657,8 +696,8 @@ func Test_maxNodeResourcesExtendedResourceOnSubsetOfNodes(t *testing.T) {
 			if fooIdx < 0 {
 				t.Fatalf("iteration %d: %s not registered in vector map", i, fooResource)
 			}
-			if got := mnr.maxResources.Get(fooIdx); got != 5000 {
-				t.Fatalf("iteration %d: maxResources[%s] = %v, want 5000", i, fooResource, got)
+			if got := mnr.maxResources.Get(fooIdx); got != 5 {
+				t.Fatalf("iteration %d: maxResources[%s] = %v, want 5", i, fooResource, got)
 			}
 		}
 	})

--- a/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
+++ b/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
@@ -22,22 +22,6 @@ import (
 	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
 )
 
-func buildTestNodes(nodesResourceLists map[string]v1.ResourceList) map[string]*node_info.NodeInfo {
-	var allLists []v1.ResourceList
-	for _, rl := range nodesResourceLists {
-		allLists = append(allLists, rl)
-	}
-	vm := resource_info.BuildResourceVectorMap(allLists)
-	result := make(map[string]*node_info.NodeInfo, len(nodesResourceLists))
-	for name, rl := range nodesResourceLists {
-		result[name] = &node_info.NodeInfo{
-			AllocatableVector: resource_info.NewResourceVectorFromResourceList(rl, vm),
-			VectorMap:         vm,
-		}
-	}
-	return result
-}
-
 func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 	type args struct {
 		nodePoolName       string
@@ -387,6 +371,26 @@ func Test_extendedResourcesAreNotScaledByThousand(t *testing.T) {
 	}
 }
 
+func buildTestNodes(nodesResourceLists map[string]v1.ResourceList) map[string]*node_info.NodeInfo {
+	var allLists []v1.ResourceList
+	for _, rl := range nodesResourceLists {
+		allLists = append(allLists, rl)
+	}
+	vm := resource_info.BuildResourceVectorMap(allLists)
+	result := make(map[string]*node_info.NodeInfo, len(nodesResourceLists))
+	for name, rl := range nodesResourceLists {
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status: v1.NodeStatus{
+				Allocatable: rl,
+				Capacity:    rl,
+			},
+		}
+		result[name] = node_info.NewNodeInfo(node, nil, vm)
+	}
+	return result
+}
+
 func makeDRAResourceSlice(name, nodeName, driver string, deviceCount int) *resourceapi.ResourceSlice {
 	devices := make([]resourceapi.Device, deviceCount)
 	for i := 0; i < deviceCount; i++ {
@@ -416,15 +420,14 @@ func buildNodesFromResourceSlices(slices []*resourceapi.ResourceSlice, nodeBases
 	vm := resource_info.BuildResourceVectorMap(allLists)
 	nodesMap := make(map[string]*node_info.NodeInfo)
 	for nodeName, baseList := range nodeBases {
-		allocVec := resource_info.NewResourceVectorFromResourceList(baseList, vm)
-		ni := &node_info.NodeInfo{
-			Name:              nodeName,
-			AllocatableVector: allocVec,
-			IdleVector:        allocVec.Clone(),
-			ReleasingVector:   resource_info.NewResourceVector(vm),
-			UsedVector:        resource_info.NewResourceVector(vm),
-			VectorMap:         vm,
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			Status: v1.NodeStatus{
+				Allocatable: baseList,
+				Capacity:    baseList,
+			},
 		}
+		ni := node_info.NewNodeInfo(node, nil, vm)
 		var draGPUCount int64
 		for _, slice := range slicesByNode[nodeName] {
 			if resources.IsGPUDeviceClass(slice.Spec.Driver) {
@@ -607,11 +610,14 @@ func buildTestNodesIncremental(scanOrder []string, nodesResourceLists map[string
 	for _, name := range scanOrder {
 		rl := nodesResourceLists[name]
 		vm.AddResourceList(rl)
-		result[name] = &node_info.NodeInfo{
-			Name:              name,
-			AllocatableVector: resource_info.ResourceFromResourceList(rl).ToVector(vm),
-			VectorMap:         vm,
+		node := &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Status: v1.NodeStatus{
+				Allocatable: rl,
+				Capacity:    rl,
+			},
 		}
+		result[name] = node_info.NewNodeInfo(node, nil, vm)
 	}
 	return result, vm
 }


### PR DESCRIPTION
# Description
Backport of #2127 to `v0.16`.