### PR TITLE
fix(ci): disable control-plane ServiceMonitors and pin prometheus chart in e2e setup

### DIFF
--- a/.github/actions/setup-e2e-cluster/action.yaml
+++ b/.github/actions/setup-e2e-cluster/action.yaml
@@ -96,9 +96,17 @@ runs:
         helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update
         helm repo update prometheus-community
         helm install prometheus prometheus-community/kube-prometheus-stack --namespace monitoring --create-namespace \
+        --version 90.0.0 \
         --set "alertmanager.enabled=false" \
         --set "grafana.enabled=false" \
         --set "prometheus.enabled=false" \
+        --set "kubeApiServer.enabled=false" \
+        --set "kubelet.enabled=false" \
+        --set "kubeControllerManager.enabled=false" \
+        --set "coreDns.enabled=false" \
+        --set "kubeEtcd.enabled=false" \
+        --set "kubeScheduler.enabled=false" \
+        --set "kubeProxy.enabled=false" \
         --wait
 
     - name: Set up Go

--- a/hack/setup-e2e-cluster.sh
+++ b/hack/setup-e2e-cluster.sh
@@ -112,6 +112,7 @@ echo "Deploying Prometheus Operator..."
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update
 helm repo update prometheus-community
 helm install prometheus prometheus-community/kube-prometheus-stack --namespace monitoring --create-namespace \
+    --version 90.0.0 \
     --set "alertmanager.enabled=false" \
     --set "grafana.enabled=false" \
     --set "prometheus.enabled=false" \

--- a/hack/setup-e2e-cluster.sh
+++ b/hack/setup-e2e-cluster.sh
@@ -115,6 +115,13 @@ helm install prometheus prometheus-community/kube-prometheus-stack --namespace m
     --set "alertmanager.enabled=false" \
     --set "grafana.enabled=false" \
     --set "prometheus.enabled=false" \
+    --set "kubeApiServer.enabled=false" \
+    --set "kubelet.enabled=false" \
+    --set "kubeControllerManager.enabled=false" \
+    --set "coreDns.enabled=false" \
+    --set "kubeEtcd.enabled=false" \
+    --set "kubeScheduler.enabled=false" \
+    --set "kubeProxy.enabled=false" \
     --wait
 
 # Install VPA and its prerequisites


### PR DESCRIPTION
# Description
Backport of #2125 to `v0.16`.