### PR TITLE
ci: backport action with merge commits

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -5,6 +5,12 @@ name: Backport PR
 on:
   pull_request_target:
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to backport
+        required: true
+        type: number
 permissions:
   contents: write # so it can comment
   pull-requests: write # so it can create pull requests
@@ -13,7 +19,7 @@ jobs:
     name: Backport pull request
     runs-on: ubuntu-latest
     # Don't run on closed unmerged pull requests
-    if: github.event.pull_request.merged
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged
     steps:
       - uses: actions/checkout@v6
       - name: Create backport pull requests
@@ -22,6 +28,8 @@ jobs:
           github_token: ${{ secrets.KAIBOT_TOKEN }}
           pull_title: "${pull_title}"
           cherry_picking: pull_request_head
+          merge_commits: skip
+          source_pr_number: ${{ inputs.pr_number }}
           # Backports carry the original PR's changie fragment (a new file, so no conflict).
           # Propagate changelog-exemption labels so exempt PRs still pass validate-changelog.
           copy_labels_pattern: "skip-changelog|dependencies"


### PR DESCRIPTION
## Description

Allow backporing using the action of PRs with merge commits and also easily trigger it manually with a PR number (instead of looking for the previous action and re-running it)

## Related Issues

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [ ] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [ ] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.
