### PR TITLE
fix(scheduler): consistent resourceList parsing for resourceInfo and node vector - v0.12

### DIFF
--- a/.changes/unreleased/fixed-20260907-220926.yaml
+++ b/.changes/unreleased/fixed-20260907-220926.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Bug fix: consistent resourceList parsing for resourceInfo and node vector

--- a/pkg/scheduler/api/common_info/job_errors_test.go
+++ b/pkg/scheduler/api/common_info/job_errors_test.go
@@ -440,7 +440,7 @@ func TestNewTopologyInsufficientResourcesError(t *testing.T) {
 					subGroupName:     "subgroup1",
 					reason:           UnschedulableWorkloadReason,
 					messages:         []string{"node-group(s) didn't have enough resources: custom.io/res"},
-					detailedMessages: []string{"domain1 didn't have enough resource: custom.io/res, requested: 5000, available: 3000"},
+					detailedMessages: []string{"domain1 didn't have enough resource: custom.io/res, requested: 5, available: 3"},
 				},
 				nodesGroupName: "domain1",
 			},

--- a/pkg/scheduler/api/resource_info/base_resources.go
+++ b/pkg/scheduler/api/resource_info/base_resources.go
@@ -13,11 +13,11 @@ import (
 )
 
 const (
-	minMilliCPU             float64 = 10
-	minMilliScalarResources int64   = 10
-	MinMemory               float64 = 10 * 1024 * 1024
-	MilliCPUToCores         float64 = 1000
-	MemoryToGB              float64 = 1000 * 1000 * 1000
+	minMilliCPU        float64 = 10
+	minScalarResources int64   = 0
+	MinMemory          float64 = 10 * 1024 * 1024
+	MilliCPUToCores    float64 = 1000
+	MemoryToGB         float64 = 1000 * 1000 * 1000
 )
 
 type BaseResource struct {
@@ -104,7 +104,7 @@ func (r *BaseResource) ToResourceList() v1.ResourceList {
 	rl[v1.ResourceCPU] = *resource.NewMilliQuantity(int64(r.milliCpu), resource.DecimalSI)
 	rl[v1.ResourceMemory] = *resource.NewQuantity(int64(r.memory), resource.DecimalSI)
 	for rName, rQuant := range r.scalarResources {
-		rl[rName] = *resource.NewMilliQuantity(int64(rQuant), resource.DecimalSI)
+		rl[rName] = *resource.NewQuantity(int64(rQuant), resource.DecimalSI)
 	}
 
 	return rl
@@ -115,7 +115,7 @@ func (r *BaseResource) IsEmpty() bool {
 		return false
 	}
 	for _, rQuant := range r.scalarResources {
-		if rQuant >= minMilliScalarResources {
+		if rQuant >= minScalarResources {
 			return false
 		}
 	}

--- a/pkg/scheduler/api/resource_info/base_resources.go
+++ b/pkg/scheduler/api/resource_info/base_resources.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	minMilliCPU        float64 = 10
-	minScalarResources int64   = 0
+	minScalarResources int64   = 1
 	MinMemory          float64 = 10 * 1024 * 1024
 	MilliCPUToCores    float64 = 1000
 	MemoryToGB         float64 = 1000 * 1000 * 1000

--- a/pkg/scheduler/api/resource_info/resource_info.go
+++ b/pkg/scheduler/api/resource_info/resource_info.go
@@ -69,7 +69,7 @@ func ResourceFromResourceList(rList v1.ResourceList) *Resource {
 			} else if rName == v1.ResourceEphemeralStorage || rName == v1.ResourceStorage {
 				r.scalarResources[rName] += rQuant.Value()
 			} else if k8s_internal.IsScalarResourceName(rName) {
-				r.scalarResources[rName] += rQuant.MilliValue()
+				r.scalarResources[rName] += rQuant.Value()
 			}
 		}
 	}

--- a/pkg/scheduler/api/resource_info/resource_requirment.go
+++ b/pkg/scheduler/api/resource_info/resource_requirment.go
@@ -61,7 +61,7 @@ func RequirementsFromResourceList(rl v1.ResourceList) *ResourceRequirements {
 			if IsMigResource(rName) {
 				r.MigResources()[rName] += rQuant.Value()
 			} else if k8s_internal.IsScalarResourceName(rName) {
-				r.scalarResources[rName] += rQuant.MilliValue()
+				r.scalarResources[rName] += rQuant.Value()
 			} else if rName == v1.ResourceEphemeralStorage || rName == v1.ResourceStorage {
 				r.scalarResources[rName] += rQuant.Value()
 			}

--- a/pkg/scheduler/api/resource_info/resource_requirment_test.go
+++ b/pkg/scheduler/api/resource_info/resource_requirment_test.go
@@ -181,17 +181,10 @@ var _ = Describe("ResourceRequirements Info internal logic", func() {
 
 		It("Extended resources consistent parsing", func() {
 			const rdmaResourceName = v1.ResourceName("intel.com/mlnx_sriov_rdma")
-			resourceList := v1.ResourceList{
+			resourceInfo := RequirementsFromResourceList(v1.ResourceList{
 				rdmaResourceName: resource.MustParse("4"),
-			}
-
-			resourceInfo := RequirementsFromResourceList(resourceList)
+			})
 			Expect(resourceInfo.Get(rdmaResourceName)).To(Equal(float64(4)))
-
-			// The vector conversion used for node allocatable elsewhere must agree.
-			vectorMap := BuildResourceVectorMap([]v1.ResourceList{resourceList})
-			nodeVector := NewResourceVectorFromResourceList(resourceList, vectorMap)
-			Expect(resourceInfo.ToVector(vectorMap)).To(Equal(nodeVector))
 		})
 	})
 })

--- a/pkg/scheduler/api/resource_info/resource_requirment_test.go
+++ b/pkg/scheduler/api/resource_info/resource_requirment_test.go
@@ -57,7 +57,7 @@ var _ = Describe("ResourceRequirements Info internal logic", func() {
 				v1.ResourceName("kai.scheduler/test-resource"): resource.MustParse("1"),
 			}
 			resourceInfo := RequirementsFromResourceList(resourceList)
-			Expect(resourceInfo.Get("kai.scheduler/test-resource")).To(Equal(float64(1000)))
+			Expect(resourceInfo.Get("kai.scheduler/test-resource")).To(Equal(float64(1)))
 
 			newResourceList := resourceInfo.ToResourceList()
 			compareResourceLists(resourceList, newResourceList)
@@ -81,7 +81,7 @@ var _ = Describe("ResourceRequirements Info internal logic", func() {
 			clone := resourceInfo.Clone()
 			Expect(clone.Cpu()).To(Equal(float64(1000)))
 			Expect(clone.Memory()).To(Equal(float64(5000000000)))
-			Expect(clone.Get("kai.scheduler/test-resource")).To(Equal(float64(1000)))
+			Expect(clone.Get("kai.scheduler/test-resource")).To(Equal(float64(1)))
 		})
 	})
 
@@ -177,6 +177,21 @@ var _ = Describe("ResourceRequirements Info internal logic", func() {
 				})
 				Expect(resourceInfo2.LessInAtLeastOneResource(resourceInfo1)).To(BeTrue())
 			})
+		})
+
+		It("Extended resources consistent parsing", func() {
+			const rdmaResourceName = v1.ResourceName("intel.com/mlnx_sriov_rdma")
+			resourceList := v1.ResourceList{
+				rdmaResourceName: resource.MustParse("4"),
+			}
+
+			resourceInfo := RequirementsFromResourceList(resourceList)
+			Expect(resourceInfo.Get(rdmaResourceName)).To(Equal(float64(4)))
+
+			// The vector conversion used for node allocatable elsewhere must agree.
+			vectorMap := BuildResourceVectorMap([]v1.ResourceList{resourceList})
+			nodeVector := NewResourceVectorFromResourceList(resourceList, vectorMap)
+			Expect(resourceInfo.ToVector(vectorMap)).To(Equal(nodeVector))
 		})
 	})
 })

--- a/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
+++ b/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
@@ -309,17 +309,19 @@ func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 func Test_extendedResourcesAreNotScaledByThousand(t *testing.T) {
 	const rdmaResourceName = v1.ResourceName("intel.com/mlnx_sriov_rdma")
 
-	nodesMap := map[string]*node_info.NodeInfo{
-		"n1": {
-			Allocatable: resource_info.ResourceFromResourceList(v1.ResourceList{
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Status: v1.NodeStatus{
+			Allocatable: v1.ResourceList{
 				v1.ResourceCPU:                resource.MustParse("96"),
 				v1.ResourceMemory:             resource.MustParse("1000Gi"),
 				resource_info.GPUResourceName: resource.MustParse("8"),
 				v1.ResourcePods:               resource.MustParse("110"),
 				rdmaResourceName:              resource.MustParse("8"),
-			}),
+			},
 		},
 	}
+	nodesMap := map[string]*node_info.NodeInfo{"n1": node_info.NewNodeInfo(node, nil)}
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "name1", Namespace: "n1"},

--- a/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
+++ b/pkg/scheduler/k8s_internal/predicates/maxNodeResources_test.go
@@ -305,3 +305,39 @@ func Test_podToMaxNodeResourcesFiltering(t *testing.T) {
 		})
 	}
 }
+
+func Test_extendedResourcesAreNotScaledByThousand(t *testing.T) {
+	const rdmaResourceName = v1.ResourceName("intel.com/mlnx_sriov_rdma")
+
+	nodesMap := map[string]*node_info.NodeInfo{
+		"n1": {
+			Allocatable: resource_info.ResourceFromResourceList(v1.ResourceList{
+				v1.ResourceCPU:                resource.MustParse("96"),
+				v1.ResourceMemory:             resource.MustParse("1000Gi"),
+				resource_info.GPUResourceName: resource.MustParse("8"),
+				v1.ResourcePods:               resource.MustParse("110"),
+				rdmaResourceName:              resource.MustParse("8"),
+			}),
+		},
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "name1", Namespace: "n1"},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{rdmaResourceName: resource.MustParse("4")},
+						Limits:   v1.ResourceList{rdmaResourceName: resource.MustParse("4")},
+					},
+				},
+			},
+		},
+	}
+
+	mnr := NewMaxNodeResourcesPredicate(nodesMap, "")
+	if _, status := mnr.PreFilter(nil, nil, pod, nil); status != nil {
+		t.Fatalf("PreFilter() rejected a pod requesting 4 %s on a node with 8: %v", rdmaResourceName, status.Message())
+	}
+}


### PR DESCRIPTION
# Description
Backport of #2127 to `v0.12`.