### PR TITLE
fix(scheduler): Do not grant the GPU-sharing node score to pods that request no GPU

### DIFF
--- a/.changes/unreleased/fixed-20260911-181500.yaml
+++ b/.changes/unreleased/fixed-20260911-181500.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: |-
+  Do not grant the GPU-sharing node score to pods that request no GPU
+custom:
+  Issue: "2154"
+  Author: universome

--- a/pkg/scheduler/plugins/gpusharingorder/gpusharingorder.go
+++ b/pkg/scheduler/plugins/gpusharingorder/gpusharingorder.go
@@ -28,6 +28,11 @@ func (g *gpuSharingOrderPlugin) OnSessionOpen(ssn *framework.Session) {
 
 func (g *gpuSharingOrderPlugin) nodeOrderFn(pod *pod_info.PodInfo, node *node_info.NodeInfo) (float64, error) {
 	score := 0.0
+
+	if !pod.IsSharedGPURequest() {
+		return score, nil
+	}
+
 	for gpuGroup := range node.UsedSharedGPUsMemory {
 		if !node.IsTaskFitOnGpuGroup(&pod.GpuRequirement, gpuGroup) {
 			continue

--- a/pkg/scheduler/plugins/gpusharingorder/gpusharingorder_test.go
+++ b/pkg/scheduler/plugins/gpusharingorder/gpusharingorder_test.go
@@ -1,0 +1,59 @@
+// Copyright 2025 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+package gpusharingorder
+
+import (
+	"testing"
+
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/node_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/pod_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/api/resource_info"
+	"github.com/kai-scheduler/KAI-scheduler/pkg/scheduler/plugins/scores"
+)
+
+// A node with one shared GPU that has half its memory in use and nothing releasing.
+func nodeWithUsedSharedGpu() *node_info.NodeInfo {
+	return &node_info.NodeInfo{
+		Name:                   "n1",
+		MemoryOfEveryGpuOnNode: node_info.DefaultGpuMemory,
+		GpuSharingNodeInfo: node_info.GpuSharingNodeInfo{
+			ReleasingSharedGPUs:       map[string]bool{},
+			UsedSharedGPUsMemory:      map[string]int64{"0": node_info.DefaultGpuMemory / 2},
+			ReleasingSharedGPUsMemory: map[string]int64{},
+			AllocatedSharedGPUsMemory: map[string]int64{"0": node_info.DefaultGpuMemory / 2},
+		},
+	}
+}
+
+func TestNodeOrderFn(t *testing.T) {
+	plugin := &gpuSharingOrderPlugin{}
+	node := nodeWithUsedSharedGpu()
+
+	fractionPod := &pod_info.PodInfo{
+		ResourceRequestType: pod_info.RequestTypeFraction,
+		GpuRequirement:      *resource_info.NewGpuResourceRequirementWithGpus(0.5, 0),
+	}
+	score, err := plugin.nodeOrderFn(fractionPod, node)
+	if err != nil || score != scores.GpuSharing {
+		t.Fatalf("fraction pod: expected score %v on a node with a shared GPU it fits, got %v (err %v)", scores.GpuSharing, score, err)
+	}
+
+	cpuOnlyPod := &pod_info.PodInfo{
+		ResourceRequestType: pod_info.RequestTypeRegular,
+		GpuRequirement:      *resource_info.NewGpuResourceRequirementWithGpus(0, 0),
+	}
+	score, err = plugin.nodeOrderFn(cpuOnlyPod, node)
+	if err != nil || score != 0 {
+		t.Fatalf("cpu-only pod: expected score 0 on a node with shared GPUs, got %v (err %v)", score, err)
+	}
+
+	wholeGpuPod := &pod_info.PodInfo{
+		ResourceRequestType: pod_info.RequestTypeRegular,
+		GpuRequirement:      *resource_info.NewGpuResourceRequirementWithGpus(1, 0),
+	}
+	score, err = plugin.nodeOrderFn(wholeGpuPod, node)
+	if err != nil || score != 0 {
+		t.Fatalf("whole-gpu pod: expected score 0 on a node with shared GPUs, got %v (err %v)", score, err)
+	}
+}


### PR DESCRIPTION
## Description

There is an issue that when we launch CPU-only jobs on a cluster with heterogenous compute (GPU nodes + CPU-only nodes), they receive a huge score bump of +1000 to be scheduled on the nodes with fractional GPUs. This unnecessarily congests the GPU nodes with CPU-only jobs and leaves CPU-only nodes unused.

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.
