### PR TITLE
fix(binder): stop reporting a misleading Bound event after a repeated bind failure

### DIFF
--- a/.changes/unreleased/fixed-20260911-050705.yaml
+++ b/.changes/unreleased/fixed-20260911-050705.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: |-
+  Binder no longer logs a misleading bind-success event after a bind failure on the same reconcile

--- a/pkg/binder/controllers/bindrequest_controller.go
+++ b/pkg/binder/controllers/bindrequest_controller.go
@@ -119,7 +119,7 @@ func (r *BindRequestReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 		result, err = r.UpdateStatus(ctx, bindRequest, result, err)
 		if pod != nil {
-			r.updatePodCondition(ctx, bindRequest, pod, result, err)
+			r.updatePodCondition(ctx, bindRequest, pod)
 		}
 
 		if finalError != nil {
@@ -256,7 +256,7 @@ func (r *BindRequestReconciler) UpdateStatus(
 }
 
 func (r *BindRequestReconciler) updatePodCondition(
-	ctx context.Context, bindRequest *schedulingv1alpha2.BindRequest, pod *v1.Pod, result ctrl.Result, err error,
+	ctx context.Context, bindRequest *schedulingv1alpha2.BindRequest, pod *v1.Pod,
 ) {
 	logger := log.FromContext(ctx)
 
@@ -265,7 +265,7 @@ func (r *BindRequestReconciler) updatePodCondition(
 	var eventType string
 	var reason string
 
-	if err == nil || result.RequeueAfter != 0 {
+	if bindRequest.Status.Phase == schedulingv1alpha2.BindRequestPhaseSucceeded {
 		message = fmt.Sprintf("Pod bound successfully to node %s", bindRequest.Spec.SelectedNode)
 		condition = &v1.PodCondition{
 			Type:    podBoundCondition,
@@ -278,7 +278,7 @@ func (r *BindRequestReconciler) updatePodCondition(
 	} else {
 		message = fmt.Sprintf(
 			"Failed to bind pod %s/%s to node %s: %s", pod.Namespace, pod.Name,
-			bindRequest.Spec.SelectedNode, err.Error(),
+			bindRequest.Spec.SelectedNode, bindRequest.Status.Reason,
 		)
 		condition = &v1.PodCondition{
 			Type:    podBoundCondition,

--- a/pkg/binder/controllers/bindrequest_controller_test.go
+++ b/pkg/binder/controllers/bindrequest_controller_test.go
@@ -304,6 +304,62 @@ var _ = Describe("BindRequest Controller", func() {
 				}
 			})
 		})
+
+		Context("repeated bind failure", func() {
+			It("keeps reporting BindingError instead of a misleading Bound event once the phase stops changing", func() {
+				repeatFailurePod := &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "repeat-failure-pod",
+						Namespace: "default",
+					},
+				}
+				repeatFailureNode := &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "repeat-failure-node",
+					},
+				}
+				Expect(fakeClient.Create(context.TODO(), repeatFailureNode)).Should(Succeed())
+				Expect(fakeClient.Create(context.TODO(), repeatFailurePod)).Should(Succeed())
+
+				bindRequest := baseRequest.DeepCopy()
+				bindRequest.Spec.PodName = repeatFailurePod.Name
+				bindRequest.Spec.SelectedNode = repeatFailureNode.Name
+				Expect(fakeClient.Create(context.TODO(), bindRequest)).Should(Succeed())
+
+				mockBinder := mock_binder.NewMockInterface(gomock.NewController(GinkgoT()))
+				mockBinder.EXPECT().Bind(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(errors.New("admission webhook denied the request")).Times(2)
+				mockBinder.EXPECT().Rollback(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+				reconciler.binder = mockBinder
+
+				req := ctrl.Request{
+					NamespacedName: client.ObjectKey{
+						Namespace: bindRequest.Namespace,
+						Name:      bindRequest.Name,
+					},
+				}
+
+				// first reconcile: Pending -> Failed, a real phase change
+				_, err := reconciler.Reconcile(context.TODO(), req)
+				Expect(err).Should(HaveOccurred())
+
+				// second reconcile on the same, still-Failed BindRequest: phase does not change,
+				// so UpdateStatus intentionally returns a nil error to avoid a duplicate requeue
+				_, err = reconciler.Reconcile(context.TODO(), req)
+				Expect(err).Should(BeNil())
+
+				close(fakeEventRecorder.Events)
+				var events []string
+				for event := range fakeEventRecorder.Events {
+					events = append(events, event)
+				}
+				Expect(events).To(HaveLen(2))
+				for _, event := range events {
+					Expect(event).NotTo(ContainSubstring("bound successfully"))
+					Expect(event).To(ContainSubstring("BindingError"))
+				}
+			})
+		})
 	})
 
 	Describe("UpdateStatus", func() {
@@ -381,11 +437,15 @@ var _ = Describe("BindRequest Controller", func() {
 			}
 		})
 		Context("success", func() {
+			BeforeEach(func() {
+				bindRequest.Status.Phase = schedulingv1alpha2.BindRequestPhaseSucceeded
+			})
+
 			It("updates pod condition", func() {
 				Expect(fakeClient.Create(context.TODO(), bindRequest)).Should(Succeed())
 				Expect(fakeClient.Create(context.TODO(), pod)).Should(Succeed())
 
-				reconciler.updatePodCondition(context.TODO(), bindRequest, pod, ctrl.Result{}, nil)
+				reconciler.updatePodCondition(context.TODO(), bindRequest, pod)
 
 				updatedPod := &v1.Pod{}
 				Expect(fakeClient.Get(context.TODO(), client.ObjectKeyFromObject(pod), updatedPod)).Should(Succeed())
@@ -401,7 +461,7 @@ var _ = Describe("BindRequest Controller", func() {
 				Expect(fakeClient.Create(context.TODO(), bindRequest)).Should(Succeed())
 				Expect(fakeClient.Create(context.TODO(), pod)).Should(Succeed())
 
-				reconciler.updatePodCondition(context.TODO(), bindRequest, pod, ctrl.Result{}, nil)
+				reconciler.updatePodCondition(context.TODO(), bindRequest, pod)
 
 				close(fakeEventRecorder.Events)
 
@@ -418,6 +478,8 @@ var _ = Describe("BindRequest Controller", func() {
 				expectedFailMsg string
 			)
 			BeforeEach(func() {
+				bindRequest.Status.Phase = schedulingv1alpha2.BindRequestPhaseFailed
+				bindRequest.Status.Reason = "error"
 				expectedFailMsg = fmt.Sprintf("Failed to bind pod %s/%s to node %s: error", pod.Namespace, pod.Name, bindRequest.Spec.SelectedNode)
 			})
 
@@ -425,7 +487,7 @@ var _ = Describe("BindRequest Controller", func() {
 				Expect(fakeClient.Create(context.TODO(), bindRequest)).Should(Succeed())
 				Expect(fakeClient.Create(context.TODO(), pod)).Should(Succeed())
 
-				reconciler.updatePodCondition(context.TODO(), bindRequest, pod, ctrl.Result{}, errors.New("error"))
+				reconciler.updatePodCondition(context.TODO(), bindRequest, pod)
 
 				updatedPod := &v1.Pod{}
 				Expect(fakeClient.Get(context.TODO(), client.ObjectKeyFromObject(pod), updatedPod)).Should(Succeed())
@@ -441,7 +503,7 @@ var _ = Describe("BindRequest Controller", func() {
 				Expect(fakeClient.Create(context.TODO(), bindRequest)).Should(Succeed())
 				Expect(fakeClient.Create(context.TODO(), pod)).Should(Succeed())
 
-				reconciler.updatePodCondition(context.TODO(), bindRequest, pod, ctrl.Result{}, errors.New("error"))
+				reconciler.updatePodCondition(context.TODO(), bindRequest, pod)
 
 				close(fakeEventRecorder.Events)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [Contributor Guide](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md)
2. If this PR is unfinished, please mark it as a draft

-->

## Description

When a BindRequest's bind fails and its `Status.Phase` is already `Failed` from a previous attempt (the phase doesn't change on this reconcile), `BindRequestReconciler.updatePodCondition` decided success/failure by inspecting the error/result returned from `UpdateStatus`. `UpdateStatus` intentionally returns a `nil` error in that phase-unchanged case (to avoid a duplicate controller-runtime requeue on top of its own `RequeueAfter`/backoff), but `updatePodCondition` treated that `nil` as "the bind succeeded" and recorded a `Pod bound successfully to node X` event/condition on the very same reconcile where the bind had just failed. This is the secondary "misleading event" defect called out in the linked issue.

This PR decouples `updatePodCondition`'s success/failure decision from that reused err/RequeueAfter signal and bases it directly on `bindRequest.Status.Phase`, which `UpdateStatus` always sets correctly regardless of whether it patches the object or short-circuits. As a side benefit this also fixes the same false-"Bound"-event class of bug for the (currently unused in production) `BackoffLimit`-set path, where a real failure with `RequeueAfter > 0` previously also reported a false `Bound` event. `UpdateStatus` itself, and its interaction with controller-runtime's requeue/rate-limiter handling, is left byte-for-byte unchanged.

**Out of scope:** the issue also describes a larger, separate problem — jobs whose binds repeatedly fail keep re-winning GPU allocation every scheduling cycle, starving other schedulable pods. A maintainer explicitly said that needs more design thought, and another contributor is already iterating on a design for it in the issue thread. This PR only fixes the narrower, independent misleading-event defect and does not touch that allocation/starvation behavior, so it does not fully close the linked issue.

**Validation note:** this environment has severe, pre-existing disk space constraints unrelated to this change, so `make build` (Docker-based) and the full `make test` could not be run locally. I ran the targeted package tests, vet, and lint instead (see below) and verified the regression test fails against the pre-fix logic and passes with the fix.

```
go test ./pkg/binder/controllers -run TestBindRequest -v   # 18/18 pass
go vet ./pkg/binder/controllers                             # clean
golangci-lint run pkg/binder/controllers/...                # 0 issues
gofmt -l on both changed files                               # clean
```

## Related Issues

Relates to #2075 (does not fully fix it — see "Out of scope" above)

## Checklist

> **Note:** Ensure your PR title follows the [Conventional Commits format](https://github.com/kai-scheduler/KAI-scheduler/blob/main/CONTRIBUTING.md#pr-title-guidelines) (e.g., `feat(scheduler): add new feature`)

- [x] Self-reviewed
- [x] Added/updated tests (if needed)
- [ ] Updated documentation (if needed)
- [x] Added a changelog fragment via `make changelog` (or applied the `skip-changelog` label). Do not edit `CHANGELOG.md` directly — pending fragments are folded into it at release time.

## Breaking Changes

None. `updatePodCondition`'s signature changed (dropped unused `result`/`err` params) but it is a private method with no external callers.

## Additional Notes

CI on this repo requires a maintainer to add `ok-to-test` (if gated) — happy to address anything it surfaces. Disclosing explicitly: I could not run the Docker-based `make build` or full `make test` locally due to this environment's disk space, but the targeted unit tests directly reproduce and verify the fix for the defect described here (failing before the fix, passing after).
